### PR TITLE
Expose variables to python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ __pycache__
 *.so
 *.a
 *.egg-info
+venv/
+requirements.txt
+.ctags*
+.ycm_extra_conf.py
+examples/data/
+tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 # The command add_compile_definitions, used in this file, was new in CMake version 3.12.
 cmake_minimum_required(VERSION 3.12)
 
+set( CMAKE_EXPORT_COMPILE_COMMANDS 1 )
+
 # Comment out the next line when speed is needed
 set(CMAKE_BUILD_TYPE Debug)
 add_definitions(-O2)

--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -10,31 +10,31 @@ using namespace pybind11::literals; // For documenting function arguments
 
 PYBIND11_MODULE(_booz_xform, m) {
   m.doc() = "Transformation to Boozer coordinates";
-  
+
   py::class_<Booz_xform>(m, "Booz_xform", R"(
 A class holding the input and output information for a
 transformation to Boozer coordinates)")
-    
+
     .def(py::init())
-    
+
     .def("read_wout", &Booz_xform::read_wout, R"(
 Read input information from a VMEC ``wout*.nc`` file.
 
 :param filename: The full name of the file to load.
 )",
 	 "filename"_a)
-    
+
     .def("init_from_vmec", &Booz_xform::init_from_vmec, R"(
 Handle radial interpolation of vmec results to the half grid.
 )")
-    
-    .def("run", &Booz_xform::run, R"( 
+
+    .def("run", &Booz_xform::run, R"(
 Run the transformation to Boozer coordinates on all the selected
 flux surfaces. The input arrays should be initialized before this step.)")
-    
+
     .def("write_boozmn", &Booz_xform::write_boozmn, R"(
 Write the results of the transformation to a classic ``boozmn_*.nc``
-NetCDF file. This function should only be called after 
+NetCDF file. This function should only be called after
 :func:`booz_xform.Booz_xform.run`.
 
 :param filename: The full name of the file to save.)",
@@ -46,17 +46,17 @@ Read in the results of an earlier transformation from a classic
 
 :param filename: The full name of the file to load.)",
 	 "filename"_a)
-    
+
     .def_readwrite("verbose", &Booz_xform::verbose, R"(
 Set this to 0 for no output to stdout, 1 for some output, 2 for lots
 of output)")
-    
-    .def_readwrite("asym", &Booz_xform::asym) 
+
+    .def_readwrite("asym", &Booz_xform::asym)
     .def_readwrite("nfp", &Booz_xform::nfp)
     .def_readwrite("s_in", &Booz_xform::s_in)
     .def_readwrite("mpol", &Booz_xform::mpol, R"(
 Maximum poloidal mode number for the input arrays rmnc, rmns, zmnc, and zmns)")
-    
+
     .def_readwrite("ntor", &Booz_xform::ntor)
     .def_readwrite("mnmax", &Booz_xform::mnmax)
     .def_readwrite("mpol_nyq", &Booz_xform::mpol_nyq)
@@ -98,8 +98,10 @@ Maximum poloidal mode number for the input arrays rmnc, rmns, zmnc, and zmns)")
     .def_readonly("zmnc_b", &Booz_xform::zmnc_b)
     .def_readonly("zmns_b", &Booz_xform::zmns_b)
     .def_readonly("numnc_b", &Booz_xform::numnc_b)
-    .def_readonly("numns_b", &Booz_xform::numns_b);
-    
+    .def_readonly("numns_b", &Booz_xform::numns_b)
+    .def_readonly("Boozer_G", &Booz_xform::Boozer_G)
+    .def_readonly("Boozer_I", &Booz_xform::Boozer_I);
+
 }
 
 // https://github.com/pybind/pybind11/issues/2271


### PR DESCRIPTION
This PR creates python bindings for `Booz_xform::Boozer_G` and `Booz_xform::Boozer_I`.
These are public variables of the C++ class.
Since they model interesting physical quantities, I believe they should be available in python as well.