### PR TITLE
Extended output reading and writing

### DIFF
--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -34,8 +34,8 @@ need to call this function directly.
 
 :param ns: The number of radial vmec surfaces.
 :param iotas: Iota on vmec's half grid.
-:param phis: Phi on vmec's half grid.
-:param phip: Phip on vmec's half grid.
+:param phis: Phi on vmec's full grid.
+:param phip: Phip on vmec's full grid.
 :param rmnc0: Vmec's original rmnc array, on the full grid.
 :param rmns0: Vmec's original rmns array, on the full grid.
   For stellarator-symmetric configurations this array is ignored and need not

--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -34,6 +34,8 @@ need to call this function directly.
 
 :param ns: The number of radial vmec surfaces.
 :param iotas: Iota on vmec's half grid.
+:param phis: Phi on vmec's half grid.
+:param phip: Phip on vmec's half grid.
 :param rmnc0: Vmec's original rmnc array, on the full grid.
 :param rmns0: Vmec's original rmns array, on the full grid.
   For stellarator-symmetric configurations this array is ignored and need not
@@ -61,6 +63,8 @@ need to call this function directly.
 )",
 	 "ns"_a,
 	 "iotas"_a,
+     "phis"_a,
+     "phips"_a,
 	 "rmnc0"_a,
 	 "rmns0"_a,
 	 "zmnc0"_a,
@@ -94,7 +98,7 @@ Read in the results of an earlier transformation from a classic
 	 "filename"_a)
 
     // End of functions. Now come properties that are inputs.
-    
+
     .def_readwrite("verbose", &Booz_xform::verbose, R"(
 (int, input) Set this to 0 for no output to stdout, 1 for some
 output, 2 for lots of output)")
@@ -103,11 +107,11 @@ output, 2 for lots of output)")
 (bool, input) True if the configuration is not
 stellarator-symmetric, false if the configuration is
 stellarator-symmetric.)")
-    
+
     .def_readwrite("nfp", &Booz_xform::nfp, R"(
 (int, input) Number of field periods, i.e. the discrete toroidal
 rotation symmetry.)")
-    
+
     .def_readwrite("mpol", &Booz_xform::mpol, R"(
 (int, input) Maximum poloidal mode number for the input arrays rmnc,
 rmns, zmnc, zmns, lmnc, and lmns.)")
@@ -119,11 +123,11 @@ input arrays rmnc, rmns, zmnc, zmns, lmnc, and lmns.)")
     .def_readwrite("mnmax", &Booz_xform::mnmax, R"(
 (int, input) Number of Fourier modes for the input arrays rmnc,
 rmns, zmnc, zmns, lmnc, and lmns.)")
-    
+
     .def_readwrite("mpol_nyq", &Booz_xform::mpol_nyq, R"(
 (int, input) Maximum poloidal mode number for the input arrays bmnc,
 bmns, bsubumnc, bsubumns, bsubvmnc, and bsubvmns.)")
-    
+
     .def_readwrite("ntor_nyq", &Booz_xform::ntor_nyq, R"(
 (int, input) Maximum toroidal mode number (divided by nfp) for the
 input arrays bmnc, bmns, bsubumnc, bsubumns, bsubvmnc, and bsubvmns.)")
@@ -135,7 +139,7 @@ bmnc, bmns, bsubumnc, bsubumns, bsubvmnc, and bsubvmns.)")
     .def_readwrite("xm", &Booz_xform::xm, R"(
 (1D integer array of length mnmax, input) The poloidal Fourier mode
 numbers for the input arrays rmnc, rmns, zmnc, zmns, lmnc, and lmns.)")
-    
+
     .def_readwrite("xn", &Booz_xform::xn, R"(
 (1D integer array of length mnmax, input) The toroidal Fourier mode
 numbers for the input arrays rmnc, rmns, zmnc, zmns, lmnc, and
@@ -157,39 +161,47 @@ nfp.)")
 supplied. The transformation to Boozer coordinates is not necessarily
 run on all of these surfaces, only the ones indicated by
 compute_surfs.)")
-    
+
     .def_readwrite("s_in", &Booz_xform::s_in, R"(
 (1D float array of length ns_in, input) The values of normalized
 toroidal flux s for the input data. Here, s is the toroidal flux
 normalized to the value at the plasma boundary. This information is
 not needed for the coordinate transformation itself, but is useful for
 plotting output.)")
-    
+
     .def_readwrite("iota", &Booz_xform::iota, R"(
 (1D float array of length ns_in, input) Rotational transform on the
 input radial surfaces.)")
-    
+
+    .def_readwrite("phi", &Booz_xform::phi, R"(
+(1D float array of length ns_in, input) Toroidal flux normalized by 2*pi,
+evaluated on all the magnetic surfaces for which input data was provided.)")
+
+.def_readwrite("phip", &Booz_xform::phip, R"(
+(1D float array of length ns_in, input) Poloidal flux normalized by 2*pi,
+evaluated on all the magnetic surfaces for which input data was provided.)")
+
     .def_readwrite("rmnc", &Booz_xform::rmnc, R"(
 (2D float array of size mnmax x ns_in, input) cos(m * theta_0 - n *
 zeta_0) Fourier modes of the major radius R.)")
-    
+
     .def_readwrite("rmns", &Booz_xform::rmns, R"(
 (2D float array of size mnmax x ns_in, input) sin(m * theta_0 - n *
 zeta_0) Fourier modes of the major radius R of the flux surfaces. For
 stellarator-symmetric configurations, this array is not used and need
 not be specified.)")
-    
+
     .def_readwrite("zmnc", &Booz_xform::zmnc, R"(
 (2D float array of size mnmax x ns_in, input) cos(m * theta_0 - n *
 zeta_0) Fourier modes of the Cartesian coordinate Z of the flux
 surfaces. For stellarator-symmetric configurations, this array is not
 used and need not be specified.)")
-    
+
     .def_readwrite("zmns", &Booz_xform::zmns, R"(
 (2D float array of size mnmax x ns_in, input) sin(m * theta_0 - n *
 zeta_0) Fourier modes of the Cartesian coordinate Z of the flux
 surfaces.)")
-    
+
     .def_readwrite("lmnc", &Booz_xform::lmnc, R"(
 (2D float array of size mnmax_nyq x ns_in, input) cos(m * theta_0 - n
 * zeta_0) Fourier modes of lambda = theta^* - theta_0, the difference
@@ -212,18 +224,18 @@ zeta_0) Fourier modes of the magnetic field strength B.)")
 * zeta_0) Fourier modes of the magnetic field strength B.  For
 stellarator-symmetric configurations, this array is not used and need
 not be specified.)")
-    
+
     .def_readwrite("bsubumnc", &Booz_xform::bsubumnc, R"(
 (2D float array of size mnmax_nyq x ns_in, input) cos(m * theta_0 -
 n * zeta_0) Fourier modes of B dot (d r / d theta_0) where r is the
 position vector.)")
-    
+
     .def_readwrite("bsubumns", &Booz_xform::bsubumns, R"(
 (2D float array of size mnmax_nyq x ns_in, input) sin(m * theta_0 -
 n * zeta_0) Fourier modes of B dot (d r / d theta_0) where r is the
 position vector.  For stellarator-symmetric configurations, this array
 is not used and need not be specified.)")
-    
+
     .def_readwrite("bsubvmnc", &Booz_xform::bsubvmnc, R"(
 (2D float array of size mnmax_nyq x ns_in, input) cos(m * theta_0 -
 n * zeta_0) Fourier modes of B dot (d r / d zeta_0) where r is the
@@ -234,7 +246,7 @@ position vector.)")
 n * zeta_0) Fourier modes of B dot (d r / d zeta_0) where r is the
 position vector.  For stellarator-symmetric configurations, this array
 is not used and need not be specified.)")
-    
+
     .def_readwrite("mboz", &Booz_xform::mboz, R"(
 (int, input) Maximum poloidal mode number for representing output
 quantities in Boozer coordinates.)")
@@ -251,123 +263,123 @@ specifying the flux surfaces for which the transformation to Boozer
 coordinates will be performed. All values should be >= 0 and < ns_in.
 The array compute_surfs is similar to the array jlist in the earlier
 fortran booz_xform program, with compute_surfs = jlist - 2.)")
-    
+
     .def_readwrite("aspect", &Booz_xform::aspect, R"(
 (float, input) The aspect ratio of the configuration. This value is
 not used for anything by booz_xform, and does not need to be set. It
 is provided as a means to pass this value from the input equilibrium
 to booz_xform output files.)")
-    
+
     .def_readwrite("toroidal_flux", &Booz_xform::toroidal_flux, R"(
 (float, input) The boundary toroidal flux of the configuration. This
 value is not used for anything by booz_xform, and does not need to be
 set. It is provided as a means to pass this value from the input
 equilibrium to booz_xform output files.)")
-    
+
     // End of inputs. Now come the outputs.
-    
+
     .def_readonly("ns_b", &Booz_xform::ns_b, R"(
 (int, output) Number of flux surfaces on which output data are
 available.)")
-    
+
     .def_readonly("s_b", &Booz_xform::s_b, R"(
 (1D float array of length ns_b, output) Values of normalized
 toroidal flux s defining the magnetic surfaces for the output data.)")
-    
+
     .def_readonly("mnboz", &Booz_xform::mnboz, R"(
 (int, output) Total number of Fourier modes for output data.)")
-    
+
     .def_readonly("xm_b", &Booz_xform::xm_b, R"(
 (1D int array of length mnboz, output) Poloidal mode numbers for the
 output data.)")
-		  
+
     .def_readonly("xn_b", &Booz_xform::xn_b, R"(
 (1D int array of length mnboz, output) Toroidal mode numbers for the
 output data. These values are all integer multiples of nfp.)")
-    
+
     .def_readonly("bmnc_b", &Booz_xform::bmnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes of the magnetic field strength in Boozer
 coordinates.)")
-    
+
     .def_readonly("bmns_b", &Booz_xform::bmns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes of the magnetic field strength in Boozer
 coordinates. If the configuration is stellarator-symmetric, this
 quantity is zero so the array will have size 0 x 0.)")
-    
+
     .def_readonly("gmnc_b", &Booz_xform::gmnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 Jacobian of (s, theta_B, zeta_B) coordinates.)")
-    
+
     .def_readonly("gmns_b", &Booz_xform::gmns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 Jacobian of (s, theta_B, zeta_B) coordinates. If the configuration is
 stellarator-symmetric, this quantity is zero so this array will have
 size 0 x 0.)")
-    
+
     .def_readonly("rmnc_b", &Booz_xform::rmnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 major radius R of the flux surfaces.)")
-    
+
     .def_readonly("rmns_b", &Booz_xform::rmns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 major radius R of the flux surfaces. If the configuration is
 stellarator-symmetric, this quantity is zero so this array will have
-size 0 x 0.)")    
-    
+size 0 x 0.)")
+
     .def_readonly("zmnc_b", &Booz_xform::zmnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 Cartesian coordinate Z of the flux surfaces. If the configuration is
 stellarator-symmetric, this quantity is zero so array will have size 0
 x 0.)")
-    
+
     .def_readonly("zmns_b", &Booz_xform::zmns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 Cartesian coordinate Z of the flux surfaces.)")
-    
+
     .def_readonly("numnc_b", &Booz_xform::numnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 toroidal angle difference nu = zeta_B - zeta_0. If the configuration
 is stellarator-symmetric, this quantity is zero so this array will
 have size 0 x 0.)")
-    
+
     .def_readonly("numns_b", &Booz_xform::numns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
 toroidal angle difference nu = zeta_B - zeta_0.)")
-    
+
     .def_readonly("Boozer_G", &Booz_xform::Boozer_G, R"(
 (1D float array of length ns_b, output) Coefficient of grad zeta_B
 in the covariant representation of the magnetic field vector B in
 Boozer coordinates, evaluated on the magnetic surfaces used for output
 quantities.)")
-    
+
     .def_readonly("Boozer_G_all", &Booz_xform::Boozer_G_all, R"(
 (1D float array of length ns_in, output) Coefficient of grad zeta_B
 in the covariant representation of the magnetic field vector B in
 Boozer coordinates, evaluated on all the magnetic surfaces for which
 input data was provided.)")
-    
+
     .def_readonly("Boozer_I", &Booz_xform::Boozer_I, R"(
 (1D float array of length ns_b, output) Coefficient of grad theta_B
 in the covariant representation of the magnetic field vector B in
 Boozer coordinates, evaluated on the magnetic surfaces used for output
 quantities.)")
-    
+
     .def_readonly("Boozer_I_all", &Booz_xform::Boozer_I_all, R"(
 (1D float array of length ns_in, output) Coefficient of grad theta_B
 in the covariant representation of the magnetic field vector B in
 Boozer coordinates, evaluated on all the magnetic surfaces for which
 input data was provided.)")
-    
+
     ;
 
   // Trick for passing version number from setup.py, from
@@ -378,7 +390,7 @@ input data was provided.)")
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);
 #else
     m.attr("__version__") = "dev";
-#endif  
+#endif
 }
 
 // https://github.com/pybind/pybind11/issues/2271

--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -21,8 +21,10 @@ transformation to Boozer coordinates)")
 Read input information from a VMEC ``wout*.nc`` file.
 
 :param filename: The full name of the file to load.
+:param flux: If true, the poloidal flux is read. (Defaults to false)
 )",
-	 "filename"_a)
+	 "filename"_a,
+     "flux"_a=false)
 
     .def("init_from_vmec", &Booz_xform::init_from_vmec, R"(
 Handle conversion of the radial grids used in vmec to to the radial
@@ -34,8 +36,6 @@ need to call this function directly.
 
 :param ns: The number of radial vmec surfaces.
 :param iotas: Iota on vmec's half grid.
-:param phis: Phi on vmec's full grid.
-:param phip: Phip on vmec's full grid.
 :param rmnc0: Vmec's original rmnc array, on the full grid.
 :param rmns0: Vmec's original rmns array, on the full grid.
   For stellarator-symmetric configurations this array is ignored and need not
@@ -60,11 +60,10 @@ need to call this function directly.
 :param bsubvmns0: Vmec's original bsubvmns array, on the half grid.
   For stellarator-symmetric configurations this array is ignored and need not
   be specified.
+:param phip: Phip on vmec's full grid. (Defaults to empty Vector)
 )",
 	 "ns"_a,
 	 "iotas"_a,
-     "phis"_a,
-     "phips"_a,
 	 "rmnc0"_a,
 	 "rmns0"_a,
 	 "zmnc0"_a,
@@ -76,7 +75,8 @@ need to call this function directly.
 	 "bsubumnc0"_a,
 	 "bsubumns0"_a,
 	 "bsubvmnc0"_a,
-	 "bsubvmns0"_a)
+	 "bsubvmns0"_a,
+     "phips"_a=defaultInitPtr)
 
     .def("run", &Booz_xform::run, R"(
 Run the transformation to Boozer coordinates on all the selected

--- a/src/_booz_xform/booz_xform.hpp
+++ b/src/_booz_xform/booz_xform.hpp
@@ -5,14 +5,14 @@
 #include <valarray>
 #include "vector_matrix.hpp"
 
-namespace booz_xform {  
+namespace booz_xform {
 
   const boozfloat pi = 3.141592653589793;
   const boozfloat twopi = 2.0 * pi;
   const boozfloat mu0 = (4.0e-7) * pi;
 
   int driver(int, char**);
-  
+
   // Trick for passing version number from setup.py to C++, from
   // https://github.com/pybind/cmake_example/blob/master/src/main.cpp
 #define STRINGIFY(x) #x
@@ -22,7 +22,7 @@ namespace booz_xform {
 #else
   const std::string version = "development version";
 #endif
-  
+
   class Booz_xform {
   private:
     int nu2_b; //!< Not sure
@@ -42,12 +42,12 @@ namespace booz_xform {
     Matrix cosn_nyq; //!< Stores cos(n*zeta) for xn_nyq
     Matrix sinm_nyq; //!< Stores sin(m*theta) for xm_nyq
     Matrix sinn_nyq; //!< Stores sin(n*zeta) for xn_nyq
-    
+
     void defaults();
     void check_accuracy(int, int, Vector&, Vector&, Vector&, Matrix&, Matrix&, Matrix&, Matrix&);
-    
+
   public:
-      
+
     /* Public variables are labeled below as being an input or
        output. The input quantities should be set before calling
        run(). (Many of these input quantities can be set by calling
@@ -130,7 +130,7 @@ namespace booz_xform {
 	indicated by compute_surfs.
      */
     int ns_in;
-    
+
     /** (size ns_in, input) Values of normalized toroidal flux for
 	which the input data is stored. These numbers are used only
 	for plotting.
@@ -146,7 +146,7 @@ namespace booz_xform {
 	Fourier modes of the major radius R.
      */
     Matrix rmnc;
-    
+
     /** (size mnmax x ns_in, input) sin(m * theta_0 - n * zeta_0)
 	Fourier modes of the major radius R. For stellarator-symmetric
 	configurations, this array is not used and need not be
@@ -160,7 +160,7 @@ namespace booz_xform {
 	is not used and need not be specified.
      */
     Matrix zmnc;
-    
+
     /** (size mnmax x ns_in, input) sin(m * theta_0 - n * zeta_0)
 	Fourier modes of the Cartesian coordinate Z of the flux
 	surfaces.
@@ -175,7 +175,7 @@ namespace booz_xform {
 	specified.
     */
     Matrix lmnc;
-    
+
     /** (size mnmax x ns_in, input) sin(m * theta_0 - n zeta_0)
 	Fourier modes of lambda = theta^* - theta_0, the difference
 	between the original poloidal angle theta_0 and the straight
@@ -187,7 +187,7 @@ namespace booz_xform {
 	Fourier modes of the magnetic field strength B.
      */
     Matrix bmnc;
-    
+
     /** (size mnmax_nyq x ns_in, input) sin(m * theta_0 - n * zeta_0)
 	Fourier modes of the magnetic field strength B. For
 	stellarator-symmetric configurations, this array is not used
@@ -207,7 +207,7 @@ namespace booz_xform {
 	this array is not used and need not be specified.
     */
     Matrix bsubumns;
-    
+
     /** (size mnmax_nyq x ns_in, input) cos(m * theta_0 - n * zeta_0)
 	Fourier modes of B dot (d r / d zeta_0) where r is the
 	position vector.
@@ -232,7 +232,7 @@ namespace booz_xform {
 	n=-20, -10, 0, 10, 20.
      */
     int nboz;
-    
+
     /** (input) Indices of ns_in-sized radial arrays, specifying the
 	flux surfaces for which the transformation to Boozer
 	coordinates will be performed. All values should be >= 0 and <
@@ -256,7 +256,7 @@ namespace booz_xform {
 	booz_xform output files.
      */
     boozfloat toroidal_flux;
-    
+
     // End of the inputs. Now come the outputs.
 
     /** (output) Number of surfaces on which the transformation is
@@ -271,7 +271,7 @@ namespace booz_xform {
     Vector s_b;
 
     /** (output) Total number of Fourier modes for output data.
-     */    
+     */
     int mnboz;
 
     /** (size mnboz, output) Poloidal mode numbers used for the
@@ -383,6 +383,18 @@ namespace booz_xform {
     */
     Vector Boozer_I_all;
 
+    /** (size ns_in, output) Uniformly spaced grid going from 0 to the boundary
+    toroidal flux (not divided by (2*pi)), evaluated on all
+    the magnetic surfaces for which input data was provided.
+    */
+    Vector phi;
+
+    /** (size ns_in, output) Uniformly spaced grid going from 0 to the boundary
+    poloidal flux (not divided by (2*pi)), evaluated on all
+    the magnetic surfaces for which input data was provided.
+    */
+    Vector phip;
+
     //! Constructor
     /**
      * Create a Booz_xform object with no data.
@@ -409,6 +421,8 @@ namespace booz_xform {
      */
     void init_from_vmec(int ns,
 			Vector& iotas,
+            Vector& phis,
+            Vector& phips,
 			Matrix& rmnc,
 			Matrix& rmns,
 			Matrix& zmnc,
@@ -421,7 +435,7 @@ namespace booz_xform {
 			Matrix& bsubumns,
 			Matrix& bsubvmnc,
 			Matrix& bsubvmns);
-    
+
     //! Carry out the transformation calculation
     /**
      * This method is the main computationally intensive step, and it
@@ -437,7 +451,7 @@ namespace booz_xform {
      * @param[in] filename The full name of the boozmn_*.nc file to write.
      */
     void write_boozmn(std::string filename);
-    
+
     //! Read previously calculated results from a boozmn_*.nc output file
     /**
      * @param[in] filename The full name of the boozmn_*.nc file to read.
@@ -445,11 +459,11 @@ namespace booz_xform {
     void read_boozmn(std::string filename);
 
     void init();
-    
+
     void surface_solve(int js_b);
-    
+
   };
-  
+
 }
 
 /* Translating between fortran and C++ variable names:
@@ -470,4 +484,3 @@ namespace booz_xform {
    xjac -> d_Boozer_d_vmec
  */
 #endif
-

--- a/src/_booz_xform/booz_xform.hpp
+++ b/src/_booz_xform/booz_xform.hpp
@@ -11,6 +11,9 @@ namespace booz_xform {
   const boozfloat twopi = 2.0 * pi;
   const boozfloat mu0 = (4.0e-7) * pi;
 
+  static Vector defaultInit = Vector::Zero(0);
+  static Vector& defaultInitPtr = defaultInit;
+
   int driver(int, char**);
 
   // Trick for passing version number from setup.py to C++, from
@@ -405,7 +408,7 @@ namespace booz_xform {
      *
      * @param[in] filename The name of the VMEC wout file to load
      */
-    void read_wout(std::string filename);
+    void read_wout(std::string filename, bool flux=false);
 
     //! Handle radial dimension of vmec arrays.
     /**
@@ -419,8 +422,6 @@ namespace booz_xform {
      */
     void init_from_vmec(int ns,
 			Vector& iotas,
-            Vector& phis,
-            Vector& phips,
 			Matrix& rmnc,
 			Matrix& rmns,
 			Matrix& zmnc,
@@ -432,7 +433,8 @@ namespace booz_xform {
 			Matrix& bsubumnc,
 			Matrix& bsubumns,
 			Matrix& bsubvmnc,
-			Matrix& bsubvmns);
+			Matrix& bsubvmns,
+            Vector& phips=defaultInitPtr);
 
     //! Carry out the transformation calculation
     /**

--- a/src/_booz_xform/booz_xform.hpp
+++ b/src/_booz_xform/booz_xform.hpp
@@ -383,15 +383,13 @@ namespace booz_xform {
     */
     Vector Boozer_I_all;
 
-    /** (size ns_in, output) Uniformly spaced grid going from 0 to the boundary
-    toroidal flux (not divided by (2*pi)), evaluated on all
-    the magnetic surfaces for which input data was provided.
+    /** (size ns_in + 1, output) Uniformly spaced grid going from 0 to the boundary
+    toroidal flux (not divided by (2*pi)), evaluated on full vmec grid.
     */
     Vector phi;
 
-    /** (size ns_in, output) Uniformly spaced grid going from 0 to the boundary
-    poloidal flux (not divided by (2*pi)), evaluated on all
-    the magnetic surfaces for which input data was provided.
+    /** (size ns_in + 1, output) Uniformly spaced grid going from 0 to the boundary
+    poloidal flux (not divided by (2*pi)), evaluated on full vmec grid.
     */
     Vector phip;
 

--- a/src/_booz_xform/driver.cpp
+++ b/src/_booz_xform/driver.cpp
@@ -33,14 +33,14 @@ int booz_xform::driver(int argc, char* argv[]) {
     std::cout << "The first half-grid surface has index 0. The outermost available surface has index NS-2," << std::endl;
     std::cout << "where NS is the VMEC input parameter. You can omit <compute_surfs> from the input file," << std::endl;
     std::cout << "in which case the transformation will be performed on all half-grid surfaces." << std::endl;
-    
+
     return 0;
   }
-  
+
   std::cout << "This is xbooz_xform " << booz_xform::version << std::endl;
 
   // Read the input file.
-  
+
   std::ifstream file;
   file.open(argv[1]);
   if (!file.is_open()) throw std::runtime_error(std::string("Unable to open input file ") + argv[1]);
@@ -68,12 +68,12 @@ int booz_xform::driver(int argc, char* argv[]) {
   }
   std::cout << "Read compute_surfs =";
   for (j = 0; j < compute_surfs.size(); j++) std::cout << " " << compute_surfs[j];
-  std::cout << std::endl;  
-  
+  std::cout << std::endl;
+
   file.close();
 
   // Done reading input file. Now set up the calculation.
-  
+
   booz_xform::Booz_xform booz;
   booz.read_wout("wout_" + extension + ".nc");
 
@@ -92,13 +92,13 @@ int booz_xform::driver(int argc, char* argv[]) {
   std::cout << "About to run transformation with compute_surfs =";
   for (j = 0; j < booz.compute_surfs.size(); j++) std::cout << " " << booz.compute_surfs[j];
   std::cout << std::endl;
-  
+
   // Run the main calculation:
   booz.run();
 
   // Save results:
   booz.write_boozmn("boozmn_" + extension + ".nc");
-  
+
   std::cout << "Good bye." << std::endl;
 
   return 0;

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -10,8 +10,8 @@ using namespace booz_xform;
 
 void Booz_xform::init_from_vmec(int ns,
 				Vector& iotas,
-                Vector& phis,
-                Vector& phips,
+                Vector& phi0,
+                Vector& phip0,
 				Matrix& rmnc0,
 				Matrix& rmns0,
 				Matrix& zmnc0,
@@ -32,8 +32,8 @@ void Booz_xform::init_from_vmec(int ns,
   if (ns < 2) throw std::runtime_error("ns must be at least 2");
   if (nfp < 1) throw std::runtime_error("nfp must be at least 1");
   if (iotas.size() != ns) throw std::runtime_error("iotas.size() is not ns");
-  if (phis.size() != ns) throw std::runtime_error("phis.size() is not ns");
-  if (phips.size() != ns) throw std::runtime_error("phips.size() is not ns");
+  if (phi0.size() != ns) throw std::runtime_error("phi0.size() is not ns");
+  if (phip0.size() != ns) throw std::runtime_error("phip0.size() is not ns");
   if (xm.size() != mnmax) throw std::runtime_error("Size of xm is not mnmax");
   if (xn.size() != mnmax) throw std::runtime_error("Size of xn is not mnmax");
   if (xm_nyq.size() != mnmax_nyq) throw std::runtime_error("Size of xm_nyq is not mnmax_nyq");
@@ -90,8 +90,12 @@ void Booz_xform::init_from_vmec(int ns,
   iota.resize(ns_in);
   for (j = 0; j < ns_in; j++)  {
       iota[j] = iotas[j + 1];
-      // phi[j] = phis[j + 1];
-      phip[j] = phips[j + 1];
+  }
+  phi.resize(ns_in + 1);
+  phip.resize(ns_in + 1);
+  for (j = 0; j < ns_in + 1; j++)  {
+      phi[j] = phi0[j];
+      phip[j] = phip0[j];
   }
 
   // By default, prepare to do the Boozer transformation at all

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -10,8 +10,6 @@ using namespace booz_xform;
 
 void Booz_xform::init_from_vmec(int ns,
 				Vector& iotas,
-                Vector& phi0,
-                Vector& phip0,
 				Matrix& rmnc0,
 				Matrix& rmns0,
 				Matrix& zmnc0,
@@ -23,7 +21,8 @@ void Booz_xform::init_from_vmec(int ns,
 				Matrix& bsubumnc0,
 				Matrix& bsubumns0,
 				Matrix& bsubvmnc0,
-				Matrix& bsubvmns0) {
+				Matrix& bsubvmns0,
+                Vector& phip0) {
   int j, k;
   ns_in = ns - 1;
 
@@ -32,8 +31,10 @@ void Booz_xform::init_from_vmec(int ns,
   if (ns < 2) throw std::runtime_error("ns must be at least 2");
   if (nfp < 1) throw std::runtime_error("nfp must be at least 1");
   if (iotas.size() != ns) throw std::runtime_error("iotas.size() is not ns");
-  if (phi0.size() != ns) throw std::runtime_error("phi0.size() is not ns");
-  if (phip0.size() != ns) throw std::runtime_error("phip0.size() is not ns");
+  bool skip_phip0 = (phip0.size()==0);
+  if (!skip_phip0) {
+      if (phip0.size() != ns) throw std::runtime_error("phip0.size() is not ns");
+  }
   if (xm.size() != mnmax) throw std::runtime_error("Size of xm is not mnmax");
   if (xn.size() != mnmax) throw std::runtime_error("Size of xn is not mnmax");
   if (xm_nyq.size() != mnmax_nyq) throw std::runtime_error("Size of xm_nyq is not mnmax_nyq");
@@ -92,12 +93,15 @@ void Booz_xform::init_from_vmec(int ns,
       iota[j] = iotas[j + 1];
   }
   phi.resize(ns_in + 1);
-  phip.resize(ns_in + 1);
-  for (j = 0; j < ns_in + 1; j++)  {
-      phi[j] = phi0[j];
-      phip[j] = phip0[j];
+  for (j = 0; j <= ns_in; j++) phi[j] = (j * toroidal_flux) / ns_in;
+  if (!skip_phip0) {
+      phip.resize(ns_in + 1);
+      for (j = 0; j < ns_in + 1; j++)  {
+          phip[j] = phip0[j];
+      }
+  } else {
+     phip.resize(0);
   }
-
   // By default, prepare to do the Boozer transformation at all
   // half-grid surfaces:
   compute_surfs.resize(ns_in);

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -92,8 +92,6 @@ void Booz_xform::init_from_vmec(int ns,
   for (j = 0; j < ns_in; j++)  {
       iota[j] = iotas[j + 1];
   }
-  phi.resize(ns_in + 1);
-  for (j = 0; j <= ns_in; j++) phi[j] = (j * toroidal_flux) / ns_in;
   if (!skip_phip0) {
       phip.resize(ns_in + 1);
       for (j = 0; j < ns_in + 1; j++)  {

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -10,6 +10,8 @@ using namespace booz_xform;
 
 void Booz_xform::init_from_vmec(int ns,
 				Vector& iotas,
+                Vector& phis,
+                Vector& phips,
 				Matrix& rmnc0,
 				Matrix& rmns0,
 				Matrix& zmnc0,
@@ -26,10 +28,12 @@ void Booz_xform::init_from_vmec(int ns,
   ns_in = ns - 1;
 
   // Do some validation.
-  
+
   if (ns < 2) throw std::runtime_error("ns must be at least 2");
   if (nfp < 1) throw std::runtime_error("nfp must be at least 1");
   if (iotas.size() != ns) throw std::runtime_error("iotas.size() is not ns");
+  if (phis.size() != ns) throw std::runtime_error("phis.size() is not ns");
+  if (phips.size() != ns) throw std::runtime_error("phips.size() is not ns");
   if (xm.size() != mnmax) throw std::runtime_error("Size of xm is not mnmax");
   if (xn.size() != mnmax) throw std::runtime_error("Size of xn is not mnmax");
   if (xm_nyq.size() != mnmax_nyq) throw std::runtime_error("Size of xm_nyq is not mnmax_nyq");
@@ -52,14 +56,14 @@ void Booz_xform::init_from_vmec(int ns,
   if (bmnc0.cols() != ns) throw std::runtime_error("bmnc0 has wrong number of cols");
   if (bsubumnc0.cols() != ns) throw std::runtime_error("bsubumnc0 has wrong number of cols");
   if (bsubvmnc0.cols() != ns) throw std::runtime_error("bsubvmnc0 has wrong number of cols");
-  
+
   if (rmnc0.rows() != mnmax) throw std::runtime_error("rmnc0 has the wrong number of rows");
   if (zmns0.rows() != mnmax) throw std::runtime_error("zmns0 has the wrong number of rows");
   if (lmns0.rows() != mnmax) throw std::runtime_error("lmns0 has the wrong number of rows");
   if (bmnc0.rows() != mnmax_nyq) throw std::runtime_error("bmnc0 has the wrong number of rows");
   if (bsubumnc0.rows() != mnmax_nyq) throw std::runtime_error("bsubumnc0 has the wrong number of rows");
   if (bsubvmnc0.rows() != mnmax_nyq) throw std::runtime_error("bsubvmnc0 has the wrong number of rows");
-  
+
   if (asym) {
     if (rmns0.cols() != ns) throw std::runtime_error("rmns0 has wrong number of cols");
     if (zmnc0.cols() != ns) throw std::runtime_error("zmnc0 has wrong number of cols");
@@ -80,17 +84,21 @@ void Booz_xform::init_from_vmec(int ns,
     if (compute_surfs[j] < 0) throw std::runtime_error("compute_surfs cannot be negative");
     if (compute_surfs[j] >= ns - 1) throw std::runtime_error("compute_surfs has an entry that is too large for the given ns");
   }
-  
+
   // Done with validation.
 
   iota.resize(ns_in);
-  for (j = 0; j < ns_in; j++) iota[j] = iotas[j + 1];
+  for (j = 0; j < ns_in; j++)  {
+      iota[j] = iotas[j + 1];
+      // phi[j] = phis[j + 1];
+      phip[j] = phips[j + 1];
+  }
 
   // By default, prepare to do the Boozer transformation at all
   // half-grid surfaces:
   compute_surfs.resize(ns_in);
   for (j = 0; j < ns_in; j++) compute_surfs[j] = j;
-  
+
   // Non-Nyquist quantities:
   rmnc.resize(mnmax, ns_in);
   zmns.resize(mnmax, ns_in);
@@ -142,7 +150,7 @@ void Booz_xform::init_from_vmec(int ns,
       }
     }
   }
-  
+
   if (verbose > 0) {
     std::cout << "Read ns=" << ns << ", mpol=" << mpol << ", ntor=" << ntor
 	      << ", mnmax=" << mnmax << ", mnmax_nyq=" << mnmax_nyq << std::endl;
@@ -152,11 +160,11 @@ void Booz_xform::init_from_vmec(int ns,
       std::cout << "iota = " << iotas << std::endl;
       std::cout << "xm = " << xm << std::endl;
       std::cout << "xn = " << xn << std::endl;
-    
+
       std::cout << "rmnc, increasing ns index:";
       for (j = 0; j < 4; j++) std::cout << " " << rmnc0(0, j);
       std::cout << std::endl;
-    
+
       std::cout << "rmnc, ncreasing mnmax index:";
       for (j = 0; j < 4; j++) std::cout << " " << rmnc0(j, 0);
       std::cout << std::endl;
@@ -175,7 +183,7 @@ void Booz_xform::init_from_vmec(int ns,
   // m=1 modes, since rmnc/sqrt(s) and zmns/sqrt(s) have a finite value
   // at s=0 for the m=1 modes. For these modes, the value at s=0 is
   // found by linear extrapolation using the next two full-grid points.
-  
+
   // We will need sqrt(s) on the full and half grid:
   boozfloat hs = 1.0 / (ns - 1.0);
   Vector sqrt_s_full, sqrt_s_half;
@@ -215,13 +223,13 @@ void Booz_xform::init_from_vmec(int ns,
       for (k = 0; k < ns_in; k++) {
 	rmnc(j, k) = 0.5 * (rmnc0(j, k) / sqrt_s_full[k]
 			    + rmnc0(j, k + 1) / sqrt_s_full[k + 1]) * sqrt_s_half[k];
-	
+
 	zmns(j, k) = 0.5 * (zmns0(j, k) / sqrt_s_full[k]
 			    + zmns0(j, k + 1) / sqrt_s_full[k + 1]) * sqrt_s_half[k];
 	if (asym) {
 	  rmns(j, k) = 0.5 * (rmns0(j, k) / sqrt_s_full[k]
 			      + rmns0(j, k + 1) / sqrt_s_full[k + 1]) * sqrt_s_half[k];
-	  
+
 	  zmnc(j, k) = 0.5 * (zmnc0(j, k) / sqrt_s_full[k]
 			      + zmnc0(j, k + 1) / sqrt_s_full[k + 1]) * sqrt_s_half[k];
 	}
@@ -235,16 +243,16 @@ void Booz_xform::init_from_vmec(int ns,
 	//val_over_sqrt_s_on_axis = 2 * rmnc0(j, 1) / sqrt_s_full[1] - rmnc0(j, 2) / sqrt_s_full[2];
 	// Interpolate:
 	//rmnc(j, 1) = 0.5 * (val_over_sqrt_s_on_axis + rmnc0(j, 1) / sqrt_s_full[1]) * sqrt_s_half[0];
-	
+
 	rmnc(j, 0) = (1.5 * rmnc0(j, 1) / sqrt_s_full[1]
 		      - 0.5 * rmnc0(j, 2) / sqrt_s_full[2]) * sqrt_s_half[0];
-	
+
 	zmns(j, 0) = (1.5 * zmns0(j, 1) / sqrt_s_full[1]
 		      - 0.5 * zmns0(j, 2) / sqrt_s_full[2]) * sqrt_s_half[0];
 	if (asym) {
 	  rmns(j, 0) = (1.5 * rmns0(j, 1) / sqrt_s_full[1]
 			- 0.5 * rmns0(j, 2) / sqrt_s_full[2]) * sqrt_s_half[0];
-	
+
 	  zmnc(j, 0) = (1.5 * zmnc0(j, 1) / sqrt_s_full[1]
 			- 0.5 * zmnc0(j, 2) / sqrt_s_full[2]) * sqrt_s_half[0];
 	}
@@ -260,9 +268,9 @@ void Booz_xform::init_from_vmec(int ns,
   for (j = 0; j < mnmax; j++) output_file << std::setprecision(15) << " " << rmnc(j, 2);
   output_file.close();
   */
-  
+
   // End of radial interpolation.
-  
+
   // Set a guess for the Fourier resolution:
   mboz = 6 * mpol;
   nboz = std::max(2 * ntor - 1, 0);

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -10,7 +10,7 @@ using namespace booz_xform;
 
 void Booz_xform::read_boozmn(std::string filename) {
   int j;
-  
+
   if (verbose > 0) std::cout << "About to try reading boozmn netcdf file " << filename << std::endl;
   booz_xform::NetCDFReader nc(filename);
 
@@ -19,7 +19,8 @@ void Booz_xform::read_boozmn(std::string filename) {
   asym = (bool) asym_int;
 
   nc.get("nfp_b", nfp);
-  
+  nc.get("phi_b",phi);
+  nc.get("phip_b",phip);
   nc.get("mboz_b", mboz);
   nc.get("nboz_b", nboz);
   nc.get("mnboz_b", mnboz);
@@ -32,7 +33,7 @@ void Booz_xform::read_boozmn(std::string filename) {
   ns_b = nc.getdim("comput_surfs");
   if (verbose > 0) std::cout << "Read mboz=" << mboz << ", nboz=" << nboz <<
 		     ", mnboz=" << mnboz << ", ns_b=" << ns_b << std::endl;
-  
+
   compute_surfs.resize(ns_b);
   nc.get("jlist", compute_surfs);
   // Fortran jlist is 1-based and includes an extra 1 from the 0 at
@@ -64,7 +65,7 @@ void Booz_xform::read_boozmn(std::string filename) {
     nc.get("pmnc_b", numnc_b);
     numnc_b = -numnc_b; // p in the boozmn format is -nu in this new booz_xform.
     nc.get("gmns_b", gmns_b);
-    
+
   } else {
     // Stellarator-symmetric.
 
@@ -72,7 +73,7 @@ void Booz_xform::read_boozmn(std::string filename) {
     rmns_b.resize(0, 0);
     zmnc_b.resize(0, 0);
     numnc_b.resize(0, 0);
-    gmns_b.resize(0, 0);    
+    gmns_b.resize(0, 0);
   }
 
   // Set up the s grid for output quantites.
@@ -82,7 +83,7 @@ void Booz_xform::read_boozmn(std::string filename) {
   s_b.resize(ns_b);
   for (j = 0; j < ns_b; j++) s_b[j] = hs * (compute_surfs[j] + 0.5);
   if (verbose > 0) std::cout << "s_b=" << s_b << std::endl;
-  
+
   nc.close();
-  
+
 }

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -29,14 +29,15 @@ void Booz_xform::read_boozmn(std::string filename) {
   nc.get("ixm_b", xm_b);
   nc.get("ixn_b", xn_b);
 
-  ns_in = nc.getdim("radius");
+  int radius = nc.getdim("radius");
   Vector iota_in, Boozer_G_in, Boozer_I_in;
-  iota_in.resize(ns_in+1);
-  Boozer_G_in.resize(ns_in+1);
-  Boozer_I_in.resize(ns_in+1);
+  iota_in.resize(radius);
+  Boozer_G_in.resize(radius);
+  Boozer_I_in.resize(radius);
+  ns_in = radius - 1;
   iota.resize(ns_in);
-  Boozer_G.resize(ns_in);
-  Boozer_I.resize(ns_in);
+  Boozer_G_all.resize(ns_in);
+  Boozer_I_all.resize(ns_in);
   phi.resize(ns_in+1);
   phip.resize(ns_in+1);
   nc.get("iota_b", iota_in);
@@ -46,8 +47,8 @@ void Booz_xform::read_boozmn(std::string filename) {
   nc.get("phip_b", phip);
   for (j = 0; j < ns_in; j++) {
       iota[j] = iota_in[j+1];
-      Boozer_G[j] = Boozer_G_in[j+1];
-      Boozer_I[j] = Boozer_I_in[j+1];
+      Boozer_G_all[j] = Boozer_G_in[j+1];
+      Boozer_I_all[j] = Boozer_I_in[j+1];
   }
 
   ns_b = nc.getdim("comput_surfs");

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -19,6 +19,7 @@ void Booz_xform::read_boozmn(std::string filename) {
   asym = (bool) asym_int;
 
   nc.get("nfp_b", nfp);
+
   nc.get("mboz_b", mboz);
   nc.get("nboz_b", nboz);
   nc.get("mnboz_b", mnboz);
@@ -28,29 +29,30 @@ void Booz_xform::read_boozmn(std::string filename) {
   nc.get("ixm_b", xm_b);
   nc.get("ixn_b", xn_b);
 
-  ns_b = nc.getdim("comput_surfs");
-  if (verbose > 0) std::cout << "Read mboz=" << mboz << ", nboz=" << nboz <<
-		     ", mnboz=" << mnboz << ", ns_b=" << ns_b << std::endl;
-
+  ns_in = nc.getdim("radius");
   Vector iota_in, Boozer_G_in, Boozer_I_in;
-  iota_in.resize(ns_b+1);
-  Boozer_G_in.resize(ns_b+1);
-  Boozer_I_in.resize(ns_b+1);
-  iota.resize(ns_b);
-  Boozer_G.resize(ns_b);
-  Boozer_I.resize(ns_b);
-  phi.resize(ns_b+1);
-  phip.resize(ns_b+1);
+  iota_in.resize(ns_in+1);
+  Boozer_G_in.resize(ns_in+1);
+  Boozer_I_in.resize(ns_in+1);
+  iota.resize(ns_in);
+  Boozer_G.resize(ns_in);
+  Boozer_I.resize(ns_in);
+  phi.resize(ns_in+1);
+  phip.resize(ns_in+1);
   nc.get("iota_b", iota_in);
   nc.get("bvco_b", Boozer_G_in);
   nc.get("buco_b", Boozer_I_in);
   nc.get("phi_b", phi);
   nc.get("phip_b", phip);
-  for (j = 0; j < ns_b; j++) {
+  for (j = 0; j < ns_in; j++) {
       iota[j] = iota_in[j+1];
       Boozer_G[j] = Boozer_G_in[j+1];
       Boozer_I[j] = Boozer_I_in[j+1];
   }
+
+  ns_b = nc.getdim("comput_surfs");
+  if (verbose > 0) std::cout << "Read mboz=" << mboz << ", nboz=" << nboz <<
+		     ", mnboz=" << mnboz << ", ns_b=" << ns_b << std::endl;
 
   compute_surfs.resize(ns_b);
   nc.get("jlist", compute_surfs);

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -19,8 +19,6 @@ void Booz_xform::read_boozmn(std::string filename) {
   asym = (bool) asym_int;
 
   nc.get("nfp_b", nfp);
-  nc.get("phi_b",phi);
-  nc.get("phip_b",phip);
   nc.get("mboz_b", mboz);
   nc.get("nboz_b", nboz);
   nc.get("mnboz_b", mnboz);
@@ -33,6 +31,26 @@ void Booz_xform::read_boozmn(std::string filename) {
   ns_b = nc.getdim("comput_surfs");
   if (verbose > 0) std::cout << "Read mboz=" << mboz << ", nboz=" << nboz <<
 		     ", mnboz=" << mnboz << ", ns_b=" << ns_b << std::endl;
+
+  Vector iota_in, Boozer_G_in, Boozer_I_in;
+  iota_in.resize(ns_b+1);
+  Boozer_G_in.resize(ns_b+1);
+  Boozer_I_in.resize(ns_b+1);
+  iota.resize(ns_b);
+  Boozer_G.resize(ns_b);
+  Boozer_I.resize(ns_b);
+  phi.resize(ns_b+1);
+  phip.resize(ns_b+1);
+  nc.get("iota_b", iota_in);
+  nc.get("bvco_b", Boozer_G_in);
+  nc.get("buco_b", Boozer_I_in);
+  nc.get("phi_b", phi);
+  nc.get("phip_b", phip);
+  for (j = 0; j < ns_b; j++) {
+      iota[j] = iota_in[j+1];
+      Boozer_G[j] = Boozer_G_in[j+1];
+      Boozer_I[j] = Boozer_I_in[j+1];
+  }
 
   compute_surfs.resize(ns_b);
   nc.get("jlist", compute_surfs);

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -8,7 +8,7 @@
 
 using namespace booz_xform;
 
-void Booz_xform::read_wout(std::string filename) {
+void Booz_xform::read_wout(std::string filename, bool flux) {
   int j, k;
   if (verbose > 0) std::cout << "About to try reading VMEC wout file " << filename << std::endl;
   booz_xform::NetCDFReader nc(filename);
@@ -27,16 +27,19 @@ void Booz_xform::read_wout(std::string filename) {
   nc.get("mnmax_nyq", mnmax_nyq);
   nc.get("aspect", aspect);
 
-  Vector phi0;
-  phi0.resize(ns);
-  nc.get("phi", phi0);
-  toroidal_flux = phi0[ns - 1];
+  Vector phi0, phip0;
+  if (flux) {
+      phi0.resize(ns);
+      nc.get("phi", phi0);
+      toroidal_flux = phi0[ns - 1];
+      phip0.resize(ns);
+      nc.get("chi", phip0);
+  }
 
-  Vector iotas, phip0;
+  Vector iotas;
   iotas.resize(ns);
-  phip0.resize(ns);
+
   nc.get("iotas", iotas);
-  nc.get("chi", phip0);
 
   xm.resize(mnmax);
   xn.resize(mnmax);
@@ -93,7 +96,14 @@ void Booz_xform::read_wout(std::string filename) {
 
   nc.close();
 
-  init_from_vmec(ns, iotas, phi0, phip0, rmnc0, rmns0, zmnc0, zmns0,
-		 lmnc0, lmns0, bmnc0, bmns0,
-		 bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0);
+  if (flux) {
+      init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
+           lmnc0, lmns0, bmnc0, bmns0,
+           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0, phip0);
+  } else {
+      init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
+           lmnc0, lmns0, bmnc0, bmns0,
+           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0);
+  }
+
 }

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -27,14 +27,15 @@ void Booz_xform::read_wout(std::string filename, bool flux) {
   nc.get("mnmax_nyq", mnmax_nyq);
   nc.get("aspect", aspect);
 
-  Vector phi0, phip0;
+  Vector phip0;
   if (flux) {
-      phi0.resize(ns);
-      nc.get("phi", phi0);
-      toroidal_flux = phi0[ns - 1];
       phip0.resize(ns);
       nc.get("chi", phip0);
   }
+
+  phi.resize(ns);
+  nc.get("phi", phi);
+  toroidal_flux = phi[ns - 1];
 
   Vector iotas;
   iotas.resize(ns);

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -27,18 +27,16 @@ void Booz_xform::read_wout(std::string filename) {
   nc.get("mnmax_nyq", mnmax_nyq);
   nc.get("aspect", aspect);
 
-  Vector phi;
-  phi.resize(ns);
-  nc.get("phi", phi);
-  toroidal_flux = phi[ns - 1];
+  Vector phi0;
+  phi0.resize(ns);
+  nc.get("phi", phi0);
+  toroidal_flux = phi0[ns - 1];
 
-  Vector iotas, phis, phips;
+  Vector iotas, phip0;
   iotas.resize(ns);
-  phis.resize(ns);
-  phips.resize(ns);
+  phip0.resize(ns);
   nc.get("iotas", iotas);
-  nc.get("phis", phis);
-  nc.get("phips", phips);
+  nc.get("chi", phip0);
 
   xm.resize(mnmax);
   xn.resize(mnmax);
@@ -95,7 +93,7 @@ void Booz_xform::read_wout(std::string filename) {
 
   nc.close();
 
-  init_from_vmec(ns, iotas, phis, phips, rmnc0, rmns0, zmnc0, zmns0,
+  init_from_vmec(ns, iotas, phi0, phip0, rmnc0, rmns0, zmnc0, zmns0,
 		 lmnc0, lmns0, bmnc0, bmns0,
 		 bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0);
 }

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -16,7 +16,7 @@ void Booz_xform::read_wout(std::string filename) {
   int asym_int;
   nc.get("lasym__logical__", asym_int);
   asym = (bool) asym_int;
-  
+
   int ns;
   nc.get("ns", ns);
 
@@ -31,10 +31,14 @@ void Booz_xform::read_wout(std::string filename) {
   phi.resize(ns);
   nc.get("phi", phi);
   toroidal_flux = phi[ns - 1];
-  
-  Vector iotas;
+
+  Vector iotas, phis, phips;
   iotas.resize(ns);
+  phis.resize(ns);
+  phips.resize(ns);
   nc.get("iotas", iotas);
+  nc.get("phis", phis);
+  nc.get("phips", phips);
 
   xm.resize(mnmax);
   xn.resize(mnmax);
@@ -88,10 +92,10 @@ void Booz_xform::read_wout(std::string filename) {
     nc.get("bsubumns", bsubumns0);
     nc.get("bsubvmns", bsubvmns0);
   }
-    
+
   nc.close();
-  
-  init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
+
+  init_from_vmec(ns, iotas, phis, phips, rmnc0, rmns0, zmnc0, zmns0,
 		 lmnc0, lmns0, bmnc0, bmns0,
 		 bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0);
 }

--- a/src/_booz_xform/surface_solve.cpp
+++ b/src/_booz_xform/surface_solve.cpp
@@ -18,7 +18,7 @@ void Booz_xform::surface_solve(int js_b) {
   // js is the 0-based radial index into the input data arrays
   // js_b is the 0-based index among the subset of surfaces on which the transformation is done.
   if (verbose > 1) std::cout << "Solving for js_b=" << js_b << ", js=" << js << std::endl;
-    
+
   int jmn, m, n, abs_n, j;
 
   // Next come a bunch of work arrays that need to be independent on
@@ -52,7 +52,7 @@ void Booz_xform::surface_solve(int js_b) {
   Vector wmnc; //!< Right-hand side of eq (10) in Fourier space
   Vector d_Boozer_d_vmec; //!< The Jacobian in eq (12)
   Vector boozer_jacobian; //!< (G + iota * I) / B^2 on the (theta, zeta) grid.
-  
+
   cosm_b.setZero(n_theta_zeta, mboz + 1);
   sinm_b.setZero(n_theta_zeta, mboz + 1);
   cosn_b.setZero(n_theta_zeta, nboz + 1);
@@ -79,9 +79,9 @@ void Booz_xform::surface_solve(int js_b) {
   d_Boozer_d_vmec.setZero(n_theta_zeta);
   boozer_jacobian.setZero(n_theta_zeta);
 
-    
+
   // This next bit corresponds to transpmn.f in the fortran version.
-  
+
   // Compute the part of p that is independent of lambda (the
   // covariant source terms in eq (10)). The net p in real space is
   //
@@ -91,7 +91,7 @@ void Booz_xform::surface_solve(int js_b) {
   for (jmn = 0; jmn < mnmax_nyq; jmn++) {
     m = xm_nyq[jmn];
     n = xn_nyq[jmn];
-    
+
     if (m != 0) {
       wmns(jmn) = bsubumnc(jmn, js) / m;
       if (asym) wmnc(jmn) = -bsubumns(jmn, js) / m;
@@ -107,7 +107,7 @@ void Booz_xform::surface_solve(int js_b) {
   }
 
   // End of the part corresponding to transpmn.f in the fortran version.
-  
+
   // Beginning of the part corresponding to vcoords.f::vcoords_rz() in
   // the fortran version.  In this part, we transform R, Z, and lambda
   // from Fourier space to the real-space (theta, zeta) grid. At the
@@ -156,7 +156,7 @@ void Booz_xform::surface_solve(int js_b) {
   //std::cout << std::endl;
   //if (js_b == 1) std::cout << std::setprecision(15) << "r:" << std::endl << r << std::endl << "z:" << std::endl << z << std::endl << "lambda:" << std::endl << lambda << std::endl;
   // End of the part corresponding to vcoords_rz() in the fortran version.
-  
+
   // Beginning of the part corresponding to vcoords_w().  The goal of
   // this next section is to transform several functions from Fourier
   // space to the real-space (theta, zeta) grid. One of these function
@@ -206,7 +206,7 @@ void Booz_xform::surface_solve(int js_b) {
   // Get Boozer poloidal and toroidal angles from eq (3):
   theta_Boozer_grid = theta_grid + lambda + this_iota * nu;
   zeta_Boozer_grid = zeta_grid + nu;
-  
+
   // Derivatives of Eq (10) with respect to theta or zeta:
   d_nu_d_zeta  = one_over_GI * (d_w_d_zeta  - Boozer_I[js_b] * d_lambda_d_zeta);
   d_nu_d_theta = one_over_GI * (d_w_d_theta - Boozer_I[js_b] * d_lambda_d_theta);
@@ -228,17 +228,17 @@ void Booz_xform::surface_solve(int js_b) {
     std::cout << "d_lambda_d_theta:" << std::endl << d_lambda_d_theta << std::endl;
     std::cout << "d_lambda_d_zeta:" << std::endl << d_lambda_d_zeta << std::endl;
     std::cout << "d_Boozer_d_vmec:" << std::endl << d_Boozer_d_vmec << std::endl;
-  }    
+  }
 
   // Consider removing this test in the next line for speed:
   //if (d_Boozer_d_vmec.max() * d_Boozer_d_vmec.min() <= 0)
   //  throw std::runtime_error("d_Boozer_d_vmec crosses through 0!");
-  
+
   // End of the part located in harfun.f in the fortran version.
 
   // Now come lines from boozer.f
   // The goal now is to evaluate eq (11).
-  
+
   init_trig(theta_Boozer_grid, zeta_Boozer_grid,
 	    cosm_b, sinm_b, cosn_b, sinn_b, mboz, nboz, nfp);
 
@@ -298,12 +298,12 @@ void Booz_xform::surface_solve(int js_b) {
 
     fourier_factor = fourier_factor0;
     if (jmn == 0) fourier_factor *= 0.5;
-    
+
     for (j = 0; j < n_theta_zeta; j++) {
       tcos = (cosm_b(j, m) * cosn_b(j, abs_n)
 	      + sinm_b(j, m) * sinn_b(j, abs_n) * sign)
 	* d_Boozer_d_vmec[j] * fourier_factor;
-      
+
       tsin = (sinm_b(j, m) * cosn_b(j, abs_n)
 	      - cosm_b(j, m) * sinn_b(j, abs_n) * sign)
 	* d_Boozer_d_vmec[j] * fourier_factor;
@@ -327,41 +327,41 @@ void Booz_xform::surface_solve(int js_b) {
   if (verbose > 0) check_accuracy(js, js_b, bmod,
 				  theta_Boozer_grid, zeta_Boozer_grid,
 				  cosm_b, cosn_b, sinm_b, sinn_b);
-  
+
   if (false && js_b == 0) {
     std::ofstream output_file;
-    
+
     output_file.open("r_0");
     output_file << std::setprecision(15) << r;
     output_file.close();
   }
   if (false && js_b == 1) {
     std::ofstream output_file;
-    
+
     output_file.open("bmod");
     output_file << std::setprecision(15) << bmod;
     output_file.close();
-    
+
     output_file.open("cosm_b");
     output_file << std::setprecision(15) << cosm_b;
     output_file.close();
-    
+
     output_file.open("cosn_b");
     output_file << std::setprecision(15) << cosn_b;
     output_file.close();
-    
+
     output_file.open("sinm_b");
     output_file << std::setprecision(15) << sinm_b;
     output_file.close();
-    
+
     output_file.open("sinn_b");
     output_file << std::setprecision(15) << sinn_b;
     output_file.close();
-    
+
     output_file.open("r");
     output_file << std::setprecision(15) << r;
     output_file.close();
-    
+
     output_file.open("d_Boozer_d_vmec");
     output_file << std::setprecision(15) << d_Boozer_d_vmec;
     output_file.close();
@@ -377,33 +377,33 @@ void Booz_xform::surface_solve(int js_b) {
     std::cout << "bmnc_b:" << std::endl << std::setprecision(15);
     for (jmn = 0; jmn < mnboz; jmn++) std::cout << " " << bmnc_b(jmn, js_b);
     std::cout << std::endl;
-    
+
     std::cout << "rmnc_b:" << std::endl << std::setprecision(15);
     for (jmn = 0; jmn < mnboz; jmn++) std::cout << " " << rmnc_b(jmn, js_b);
     std::cout << std::endl;
-    
+
     std::cout << "zmns_b:" << std::endl << std::setprecision(15);
     for (jmn = 0; jmn < mnboz; jmn++) std::cout << " " << zmns_b(jmn, js_b);
     std::cout << std::endl;
-    
+
     output_file.open("bmnc_b");
     for (jmn = 0; jmn < mnboz; jmn++) output_file << std::setprecision(15) << " " << bmnc_b(jmn, js_b);
     output_file.close();
-    
+
     output_file.open("gmnc_b");
     for (jmn = 0; jmn < mnboz; jmn++) output_file << std::setprecision(15) << " " << gmnc_b(jmn, js_b);
     output_file.close();
-    
+
     output_file.open("rmnc_b");
     for (jmn = 0; jmn < mnboz; jmn++) output_file << std::setprecision(15) << " " << rmnc_b(jmn, js_b);
     output_file.close();
-    
+
     output_file.open("zmns_b");
     for (jmn = 0; jmn < mnboz; jmn++) output_file << std::setprecision(15) << " " << zmns_b(jmn, js_b);
     output_file.close();
-    
+
     output_file.open("numns_b");
     for (jmn = 0; jmn < mnboz; jmn++) output_file << std::setprecision(15) << " " << numns_b(jmn, js_b);
     output_file.close();
-  }    
+  }
 }

--- a/src/_booz_xform/write_boozmn.cpp
+++ b/src/_booz_xform/write_boozmn.cpp
@@ -59,18 +59,14 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put(mn_modes_dim, "ixn_b", xn_b, "Toroidal mode numbers n for which the Fourier amplitudes rmnc, bmnc etc are stored", "dimensionless");
 
   // Insert a 0 at the start of several arrays
-  Vector iota_b(ns_in + 1), buco_b(ns_in + 1), bvco_b(ns_in + 1), phi_b(ns_in + 1), phip_b(ns_in + 1);
+  Vector iota_b(ns_in + 1), buco_b(ns_in + 1), bvco_b(ns_in + 1);
   iota_b[0] = 0;
   buco_b[0] = 0;
   bvco_b[0] = 0;
-  phi_b[0] = 0;
-  phip_b[0] = 0;
   for (j = 0; j < ns_in; j++) {
     iota_b[j + 1] = iota[j];
     buco_b[j + 1] = Boozer_I_all[j];
     bvco_b[j + 1] = Boozer_G_all[j];
-    phi_b[j + 1] = phi[j];
-    phip_b[j + 1] = phip[j];
   }
   std::string radius_dim_comment = " The radial grid corresponds to all surfaces on which input data were available, and a 0 is prepended";
   nc.put(radius_dim, "iota_b", iota_b, "Rotational transform." + radius_dim_comment, "dimensionless");
@@ -89,11 +85,8 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put(radius_dim, "pres_b", pres_b, placeholder_str, "dimensionless");
   beta_b.setZero();
   nc.put(radius_dim, "beta_b", pres_b, placeholder_str, "dimensionless");
-  nc.put(radius_dim, "phip_b", phip_b, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
-
-  // Vector phi_b(ns_in + 1);
-  // for (j = 0; j <= ns_in; j++) phi_b[j] = (j * toroidal_flux) / ns_in;
-  nc.put(radius_dim, "phi_b", phi_b, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+  nc.put(radius_dim, "phip_b", phip, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+  nc.put(radius_dim, "phi_b", phi, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
 
   // ND arrays for N > 1:
   std::vector<dim_id_type> bmnc_dim;

--- a/src/_booz_xform/write_boozmn.cpp
+++ b/src/_booz_xform/write_boozmn.cpp
@@ -85,7 +85,13 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put(radius_dim, "pres_b", pres_b, placeholder_str, "dimensionless");
   beta_b.setZero();
   nc.put(radius_dim, "beta_b", pres_b, placeholder_str, "dimensionless");
-  nc.put(radius_dim, "phip_b", phip, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+  Vector phip_dummy(ns_in + 1);
+  phip_dummy.setZero();
+  if (phip.size()==0) {
+      nc.put(radius_dim, "phip_b", phip_dummy, placeholder_str, "Tesla * meter^2");
+  } else {
+      nc.put(radius_dim, "phip_b", phip, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+  }
   nc.put(radius_dim, "phi_b", phi, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
 
   // ND arrays for N > 1:

--- a/src/_booz_xform/write_boozmn.cpp
+++ b/src/_booz_xform/write_boozmn.cpp
@@ -24,11 +24,11 @@ void Booz_xform::write_boozmn(std::string filename) {
   // here for backwards-compatibility.
   compute_surfs_dim = nc.dim("comput_surfs", compute_surfs.size());
   pack_rad_dim = nc.dim("pack_rad", compute_surfs.size());
-  
+
   // Scalars
   std::string long_version = std::string("C++/Python booz_xform ") + version;
   nc.put("version", long_version, "");
-  
+
   int asym_int = (int) asym;
   nc.put("lasym__logical__", asym_int, "0 if the configuration is stellarator-symmetric, 1 if not", "");
 
@@ -39,7 +39,7 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put("nboz_b", nboz, "Maximum toroidal mode number n for which the Fourier amplitudes rmnc, bmnc etc are stored", "dimensionless");
   nc.put("mnboz_b", mnboz, "The total number of (m,n) pairs for which Fourier amplitudes rmnc, bmnc etc are stored.", "dimensionless");
   nc.put("aspect_b", aspect, "Aspect ratio, if provided", "dimensionless");
-  
+
   // For rmax_b, rmin_b, betaxis_b, just store 0 for now. It is hard
   // to calculate these without assuming the input is from VMEC. It is
   // better to store something rather that nothing, since some codes
@@ -50,7 +50,7 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put("rmax_b", rmax_b, placeholder_str, "dimensionless");
   nc.put("rmin_b", rmin_b, placeholder_str, "dimensionless");
   nc.put("betaxis_b", betaxis_b, placeholder_str, "dimensionless");
-  
+
   // 1D arrays
   IntVector jlist(ns_b);
   for (j = 0; j < ns_b; j++) jlist[j] = compute_surfs[j] + 2;
@@ -59,14 +59,18 @@ void Booz_xform::write_boozmn(std::string filename) {
   nc.put(mn_modes_dim, "ixn_b", xn_b, "Toroidal mode numbers n for which the Fourier amplitudes rmnc, bmnc etc are stored", "dimensionless");
 
   // Insert a 0 at the start of several arrays
-  Vector iota_b(ns_in + 1), buco_b(ns_in + 1), bvco_b(ns_in + 1);;
+  Vector iota_b(ns_in + 1), buco_b(ns_in + 1), bvco_b(ns_in + 1), phi_b(ns_in + 1), phip_b(ns_in + 1);
   iota_b[0] = 0;
   buco_b[0] = 0;
   bvco_b[0] = 0;
+  phi_b[0] = 0;
+  phip_b[0] = 0;
   for (j = 0; j < ns_in; j++) {
     iota_b[j + 1] = iota[j];
     buco_b[j + 1] = Boozer_I_all[j];
     bvco_b[j + 1] = Boozer_G_all[j];
+    phi_b[j + 1] = phi[j];
+    phip_b[j + 1] = phip[j];
   }
   std::string radius_dim_comment = " The radial grid corresponds to all surfaces on which input data were available, and a 0 is prepended";
   nc.put(radius_dim, "iota_b", iota_b, "Rotational transform." + radius_dim_comment, "dimensionless");
@@ -80,18 +84,17 @@ void Booz_xform::write_boozmn(std::string filename) {
   // For some arrays in the boozmn.nc format, correct profiles are not
   // available here. Just write vectors of zeros for
   // backwards-compatibility of the boozmn.nc files.
-  Vector pres_b(ns_in + 1), beta_b(ns_in + 1), phip_b(ns_in + 1);
+  Vector pres_b(ns_in + 1), beta_b(ns_in + 1);
   pres_b.setZero();
   nc.put(radius_dim, "pres_b", pres_b, placeholder_str, "dimensionless");
   beta_b.setZero();
   nc.put(radius_dim, "beta_b", pres_b, placeholder_str, "dimensionless");
-  beta_b.setZero();
-  nc.put(radius_dim, "phip_b", phip_b, placeholder_str, "dimensionless");
+  nc.put(radius_dim, "phip_b", phip_b, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
 
-  Vector phi_b(ns_in + 1);
-  for (j = 0; j <= ns_in; j++) phi_b[j] = (j * toroidal_flux) / ns_in;
-  nc.put(radius_dim, "phi_b", phi_b, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2"); 
-  
+  // Vector phi_b(ns_in + 1);
+  // for (j = 0; j <= ns_in; j++) phi_b[j] = (j * toroidal_flux) / ns_in;
+  nc.put(radius_dim, "phi_b", phi_b, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+
   // ND arrays for N > 1:
   std::vector<dim_id_type> bmnc_dim;
   bmnc_dim.push_back(mn_modes_dim);
@@ -99,10 +102,10 @@ void Booz_xform::write_boozmn(std::string filename) {
 
   nc.put(bmnc_dim, "bmnc_b", &bmnc_b(0, 0),
 	 "cos(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the magnetic field strength", "Tesla");
-  
+
   nc.put(bmnc_dim, "rmnc_b", &rmnc_b(0, 0),
 	 "cos(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the major radius R", "meter");
-  
+
   nc.put(bmnc_dim, "zmns_b", &zmns_b(0, 0),
 	 "sin(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the Cartesian coordinate Z", "meter");
 
@@ -110,31 +113,31 @@ void Booz_xform::write_boozmn(std::string filename) {
   Matrix pmnc_b; // pmnc_b must be declared outside the "if (asym)" block so it does not go out of scope before nc.write_and_close()
   nc.put(bmnc_dim, "pmns_b", &pmns_b(0, 0),
 	 "sin(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the angle difference zeta_VMEC - zeta_Boozer", "dimensionless");
-  
+
   nc.put(bmnc_dim, "gmn_b", &gmnc_b(0, 0),
 	 "cos(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the Boozer coordinate Jacobian (G + iota * I) / B^2", "meter/Tesla");
 
   if (asym) {
     // Stellarator-asymmetric modes:
-    
+
     nc.put(bmnc_dim, "bmns_b", &bmns_b(0, 0),
 	   "sin(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the magnetic field strength", "Tesla");
-  
+
     nc.put(bmnc_dim, "rmns_b", &rmns_b(0, 0),
 	   "sin(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the major radius R", "meter");
-  
+
     nc.put(bmnc_dim, "zmnc_b", &zmnc_b(0, 0),
 	   "cos(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the Cartesian coordinate Z", "meter");
 
     pmnc_b = -numnc_b;
     nc.put(bmnc_dim, "pmnc_b", &pmnc_b(0, 0),
 	   "cos(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the angle difference zeta_VMEC - zeta_Boozer", "dimensionless");
-    
+
     nc.put(bmnc_dim, "gmns_b", &gmns_b(0, 0),
 	   "sin(m * theta_Boozer - n * zeta_Boozer) Fourier amplitudes of the Boozer coordinate Jacobian (G + iota * I) / B^2", "meter/Tesla");
   }
-  
+
   // Done defining the NetCDF data.
   nc.write_and_close();
-  
+
 }

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -24,44 +24,49 @@ class WriteReadTest(unittest.TestCase):
                 wout_filename = 'wout_' + configuration + '.nc'
                 boozmn_filename = 'boozmn_new_' + configuration + '.nc'
                 b1 = Booz_xform()
-                b1.read_wout(os.path.join(TEST_DIR, wout_filename))
-                b1.compute_surfs = compute_surfs
-                b1.run()
-                b1.write_boozmn(boozmn_filename)
+                for flux in [True,False]:
+                    b1.read_wout(os.path.join(TEST_DIR, wout_filename),flux)
+                    b1.compute_surfs = compute_surfs
+                    b1.run()
+                    b1.write_boozmn(boozmn_filename)
 
-                # Read the results into a new object
-                b2 = Booz_xform()
-                b2.read_boozmn(boozmn_filename)
+                    # Read the results into a new object
+                    b2 = Booz_xform()
+                    b2.read_boozmn(boozmn_filename)
 
-                self.assertEqual(b1.asym, b2.asym)
-                self.assertEqual(b1.nfp, b2.nfp)
-                self.assertEqual(b1.mboz, b2.mboz)
-                self.assertEqual(b1.nboz, b2.nboz)
-                self.assertEqual(b1.mnboz, b2.mnboz)
-                self.assertEqual(b1.ns_b, b2.ns_b)
-                np.testing.assert_equal(b1.xm_b, b2.xm_b)
-                np.testing.assert_equal(b1.xn_b, b2.xn_b)
-                np.testing.assert_equal(b1.compute_surfs, b2.compute_surfs)
+                    self.assertEqual(b1.asym, b2.asym)
+                    self.assertEqual(b1.nfp, b2.nfp)
+                    self.assertEqual(b1.mboz, b2.mboz)
+                    self.assertEqual(b1.nboz, b2.nboz)
+                    self.assertEqual(b1.mnboz, b2.mnboz)
+                    self.assertEqual(b1.ns_b, b2.ns_b)
+                    np.testing.assert_equal(b1.xm_b, b2.xm_b)
+                    np.testing.assert_equal(b1.xn_b, b2.xn_b)
+                    np.testing.assert_equal(b1.compute_surfs, b2.compute_surfs)
 
-                rtol = 1e-15
-                atol = 1e-15
-                np.testing.assert_allclose(b1.bmnc_b, b2.bmnc_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.bmns_b, b2.bmns_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.gmnc_b, b2.gmnc_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.gmns_b, b2.gmns_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.rmnc_b, b2.rmnc_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.rmns_b, b2.rmns_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.zmnc_b, b2.zmnc_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.zmns_b, b2.zmns_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.numnc_b, b2.numnc_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.numns_b, b2.numns_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.s_b, b2.s_b, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.iota, b2.iota, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.Boozer_G_all, b2.Boozer_G_all, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.Boozer_I_all, b2.Boozer_I_all, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.phi,b2.phi, rtol=rtol, atol=atol)
-                np.testing.assert_allclose(b1.phip,b2.phip, rtol=rtol, atol=atol)
-                os.remove(boozmn_filename)
+                    rtol = 1e-15
+                    atol = 1e-15
+                    np.testing.assert_allclose(b1.bmnc_b, b2.bmnc_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.bmns_b, b2.bmns_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.gmnc_b, b2.gmnc_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.gmns_b, b2.gmns_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.rmnc_b, b2.rmnc_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.rmns_b, b2.rmns_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.zmnc_b, b2.zmnc_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.zmns_b, b2.zmns_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.numnc_b, b2.numnc_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.numns_b, b2.numns_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.s_b, b2.s_b, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.iota, b2.iota, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.Boozer_G_all, b2.Boozer_G_all, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.Boozer_I_all, b2.Boozer_I_all, rtol=rtol, atol=atol)
+                    np.testing.assert_allclose(b1.phi,b2.phi, rtol=rtol, atol=atol)
+                    if flux:
+                        np.testing.assert_allclose(b1.phip,b2.phip, rtol=rtol, atol=atol)
+                    else:
+                        np.testing.assert_equal(b2.phip,0)
+                        assert len(b1.phip) == 0
+                    os.remove(boozmn_filename)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -17,7 +17,7 @@ class WriteReadTest(unittest.TestCase):
                           'up_down_asymmetric_tokamak',
                           'li383_1.4m',
                           'LandremanSenguptaPlunk_section5p3']
-        
+
         for configuration in configurations:
             # Try a few different array sizes:
             for compute_surfs in [[0], [0, 5], [5, 10, 15]]:
@@ -42,7 +42,7 @@ class WriteReadTest(unittest.TestCase):
                 np.testing.assert_equal(b1.xm_b, b2.xm_b)
                 np.testing.assert_equal(b1.xn_b, b2.xn_b)
                 np.testing.assert_equal(b1.compute_surfs, b2.compute_surfs)
-                
+
                 rtol = 1e-15
                 atol = 1e-15
                 np.testing.assert_allclose(b1.bmnc_b, b2.bmnc_b, rtol=rtol, atol=atol)
@@ -56,8 +56,12 @@ class WriteReadTest(unittest.TestCase):
                 np.testing.assert_allclose(b1.numnc_b, b2.numnc_b, rtol=rtol, atol=atol)
                 np.testing.assert_allclose(b1.numns_b, b2.numns_b, rtol=rtol, atol=atol)
                 np.testing.assert_allclose(b1.s_b, b2.s_b, rtol=rtol, atol=atol)
-
+                np.testing.assert_allclose(b1.iota, b2.iota, rtol=rtol, atol=atol)
+                np.testing.assert_allclose(b1.Boozer_G_all, b2.Boozer_G_all, rtol=rtol, atol=atol)
+                np.testing.assert_allclose(b1.Boozer_I_all, b2.Boozer_I_all, rtol=rtol, atol=atol)
+                np.testing.assert_allclose(b1.phi,b2.phi, rtol=rtol, atol=atol)
+                np.testing.assert_allclose(b1.phip,b2.phip, rtol=rtol, atol=atol)
                 os.remove(boozmn_filename)
-                
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds additional output reading and writing so that a Booz_xform object can be initialized from netcdf for use with a BoozerRadialInterpolant in simsopt.

- The toroidal and poloidal fluxes are read from vmec wout and saved to the booz_xform netcdf file.
- G, I, and iota are also now read from the booz_xform netcdf file.