### PR TITLE
Phip fix

### DIFF
--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -61,6 +61,7 @@ need to call this function directly.
   For stellarator-symmetric configurations this array is ignored and need not
   be specified.
 :param phip: Phip on vmec's full grid. (Defaults to empty Vector)
+:param chi: chi on vmec's full grid. (Defaults to empty Vector)
 )",
 	 "ns"_a,
 	 "iotas"_a,
@@ -76,7 +77,8 @@ need to call this function directly.
 	 "bsubumns0"_a,
 	 "bsubvmnc0"_a,
 	 "bsubvmns0"_a,
-     "phips"_a=defaultInitPtr)
+     "phips"_a=defaultInitPtr,
+     "chi"_a=defaultInitPtr)
 
     .def("run", &Booz_xform::run, R"(
 Run the transformation to Boozer coordinates on all the selected
@@ -177,8 +179,12 @@ input radial surfaces.)")
 (1D float array of length ns_in, input) Toroidal flux normalized by 2*pi,
 evaluated on all the magnetic surfaces for which input data was provided.)")
 
-.def_readwrite("phip", &Booz_xform::phip, R"(
+    .def_readwrite("chi", &Booz_xform::chi, R"(
 (1D float array of length ns_in, input) Poloidal flux normalized by 2*pi,
+evaluated on all the magnetic surfaces for which input data was provided.)")
+
+    .def_readwrite("phip", &Booz_xform::phip, R"(
+(1D float array of length ns_in, input) Toroidal flux normalized by 2*pi,
 evaluated on all the magnetic surfaces for which input data was provided.)")
 
     .def_readwrite("rmnc", &Booz_xform::rmnc, R"(
@@ -311,12 +317,12 @@ quantity is zero so the array will have size 0 x 0.)")
     .def_readonly("gmnc_b", &Booz_xform::gmnc_b, R"(
 (2D float array of size mnboz x ns_b, output) cos(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
-Jacobian of (psi, theta_B, zeta_B) coordinates.)")
+Jacobian of (s, theta_B, zeta_B) coordinates.)")
 
     .def_readonly("gmns_b", &Booz_xform::gmns_b, R"(
 (2D float array of size mnboz x ns_b, output) sin(m * theta_B - n *
 zeta_B) Fourier modes (with respect to Boozer coordinates) of the
-Jacobian of (psi, theta_B, zeta_B) coordinates. If the configuration is
+Jacobian of (s, theta_B, zeta_B) coordinates. If the configuration is
 stellarator-symmetric, this quantity is zero so this array will have
 size 0 x 0.)")
 

--- a/src/_booz_xform/bindings.cpp
+++ b/src/_booz_xform/bindings.cpp
@@ -62,6 +62,7 @@ need to call this function directly.
   be specified.
 :param phip: Phip on vmec's full grid. (Defaults to empty Vector)
 :param chi: chi on vmec's full grid. (Defaults to empty Vector)
+:param pres: pressure on vmec's full grid. (Defaults to empty Vector)
 )",
 	 "ns"_a,
 	 "iotas"_a,
@@ -78,7 +79,8 @@ need to call this function directly.
 	 "bsubvmnc0"_a,
 	 "bsubvmns0"_a,
      "phips"_a=defaultInitPtr,
-     "chi"_a=defaultInitPtr)
+     "chi"_a=defaultInitPtr,
+     "pres"_a=defaultInitPtr)
 
     .def("run", &Booz_xform::run, R"(
 Run the transformation to Boozer coordinates on all the selected
@@ -186,6 +188,9 @@ evaluated on all the magnetic surfaces for which input data was provided.)")
     .def_readwrite("phip", &Booz_xform::phip, R"(
 (1D float array of length ns_in, input) Toroidal flux normalized by 2*pi,
 evaluated on all the magnetic surfaces for which input data was provided.)")
+
+    .def_readwrite("pres", &Booz_xform::pres, R"(
+(1D float array of length ns_in, input) Pressure on full vmec grid.)")
 
     .def_readwrite("rmnc", &Booz_xform::rmnc, R"(
 (2D float array of size mnmax x ns_in, input) cos(m * theta_0 - n *

--- a/src/_booz_xform/booz_xform.hpp
+++ b/src/_booz_xform/booz_xform.hpp
@@ -401,6 +401,8 @@ namespace booz_xform {
     */
     Vector chi;
 
+    /** Pressure evaluated on the full vmec grid **/
+    Vector pres;
 
     //! Constructor
     /**
@@ -441,7 +443,8 @@ namespace booz_xform {
 			Matrix& bsubvmnc,
 			Matrix& bsubvmns,
       Vector& phips=defaultInitPtr,
-      Vector& chi=defaultInitPtr);
+      Vector& chi=defaultInitPtr,
+      Vector& pres=defaultInitPtr);
 
     //! Carry out the transformation calculation
     /**

--- a/src/_booz_xform/booz_xform.hpp
+++ b/src/_booz_xform/booz_xform.hpp
@@ -304,13 +304,13 @@ namespace booz_xform {
 
     /** (size mnboz x ns_b, output) cos(m * theta_B - n * zeta_B)
 	Fourier modes (with respect to Boozer coordinates) of the
-	Jacobian of (psi, theta_B, zeta_B) coordinates.
+	Jacobian of (s, theta_B, zeta_B) coordinates.
     */
     Matrix gmnc_b;
 
     /** (size mnboz x ns_b, output) sin(m * theta_B - n * zeta_B)
 	Fourier modes (with respect to Boozer coordinates) of the
-	Jacobian of (psi, theta_B, zeta_B) coordinates. If the
+	Jacobian of (s, theta_B, zeta_B) coordinates. If the
 	configuration is stellarator-symmetric, this quantity is zero
 	so this array will have size 0 x 0.
     */
@@ -391,10 +391,16 @@ namespace booz_xform {
     */
     Vector phi;
 
+    /** (size ns_in + 1, output) The derivative of the toroidal flux (not divided by (2*pi))
+    with respect to s, evaluated on full vmec grid.
+    */
+    Vector phip;
+
     /** (size ns_in + 1, output) Uniformly spaced grid going from 0 to the boundary
     poloidal flux (not divided by (2*pi)), evaluated on full vmec grid.
     */
-    Vector phip;
+    Vector chi;
+
 
     //! Constructor
     /**
@@ -434,7 +440,8 @@ namespace booz_xform {
 			Matrix& bsubumns,
 			Matrix& bsubvmnc,
 			Matrix& bsubvmns,
-            Vector& phips=defaultInitPtr);
+      Vector& phips=defaultInitPtr,
+      Vector& chi=defaultInitPtr);
 
     //! Carry out the transformation calculation
     /**

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -22,7 +22,8 @@ void Booz_xform::init_from_vmec(int ns,
 				Matrix& bsubumns0,
 				Matrix& bsubvmnc0,
 				Matrix& bsubvmns0,
-                Vector& phip0) {
+        Vector& phip0,
+        Vector& chi0) {
   int j, k;
   ns_in = ns - 1;
 
@@ -34,6 +35,7 @@ void Booz_xform::init_from_vmec(int ns,
   bool skip_phip0 = (phip0.size()==0);
   if (!skip_phip0) {
       if (phip0.size() != ns) throw std::runtime_error("phip0.size() is not ns");
+      if (chi0.size() != ns) throw std::runtime_error("chi0.size() is not ns");
   }
   if (xm.size() != mnmax) throw std::runtime_error("Size of xm is not mnmax");
   if (xn.size() != mnmax) throw std::runtime_error("Size of xn is not mnmax");
@@ -94,11 +96,14 @@ void Booz_xform::init_from_vmec(int ns,
   }
   if (!skip_phip0) {
       phip.resize(ns_in + 1);
+      chi.resize(ns_in + 1);
       for (j = 0; j < ns_in + 1; j++)  {
-          phip[j] = phip0[j];
+          phip[j] = -phip0[j]/(2*pi);
+          chi[j] = chi0[j];
       }
   } else {
      phip.resize(0);
+     chi.resize(0);
   }
   // By default, prepare to do the Boozer transformation at all
   // half-grid surfaces:

--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -23,7 +23,8 @@ void Booz_xform::init_from_vmec(int ns,
 				Matrix& bsubvmnc0,
 				Matrix& bsubvmns0,
         Vector& phip0,
-        Vector& chi0) {
+        Vector& chi0,
+        Vector& pres0) {
   int j, k;
   ns_in = ns - 1;
 
@@ -36,6 +37,7 @@ void Booz_xform::init_from_vmec(int ns,
   if (!skip_phip0) {
       if (phip0.size() != ns) throw std::runtime_error("phip0.size() is not ns");
       if (chi0.size() != ns) throw std::runtime_error("chi0.size() is not ns");
+      if (pres0.size() != ns) throw std::runtime_error("pres0.size() is not ns");
   }
   if (xm.size() != mnmax) throw std::runtime_error("Size of xm is not mnmax");
   if (xn.size() != mnmax) throw std::runtime_error("Size of xn is not mnmax");
@@ -97,13 +99,16 @@ void Booz_xform::init_from_vmec(int ns,
   if (!skip_phip0) {
       phip.resize(ns_in + 1);
       chi.resize(ns_in + 1);
+      pres.resize(ns_in + 1);
       for (j = 0; j < ns_in + 1; j++)  {
           phip[j] = -phip0[j]/(2*pi);
           chi[j] = chi0[j];
+          pres[j] = pres0[j];
       }
   } else {
      phip.resize(0);
      chi.resize(0);
+     pres.resize(0);
   }
   // By default, prepare to do the Boozer transformation at all
   // half-grid surfaces:

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -40,11 +40,13 @@ void Booz_xform::read_boozmn(std::string filename) {
   Boozer_I_all.resize(ns_in);
   phi.resize(ns_in+1);
   phip.resize(ns_in+1);
+  chi.resize(ns_in+1);
   nc.get("iota_b", iota_in);
   nc.get("bvco_b", Boozer_G_in);
   nc.get("buco_b", Boozer_I_in);
   nc.get("phi_b", phi);
   nc.get("phip_b", phip);
+  nc.get("chi_b", chi);
   for (j = 0; j < ns_in; j++) {
       iota[j] = iota_in[j+1];
       Boozer_G_all[j] = Boozer_G_in[j+1];

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -47,7 +47,10 @@ void Booz_xform::read_boozmn(std::string filename) {
   nc.get("buco_b", Boozer_I_in);
   nc.get("phi_b", phi);
   nc.get("phip_b", phip);
-  nc.get("chi_b", chi);
+  try {
+      nc.get("chi_b", chi);
+  } catch (std::runtime_error error) {
+  }
   nc.get("pres_b", pres);
   for (j = 0; j < ns_in; j++) {
       iota[j] = iota_in[j+1];

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -41,12 +41,14 @@ void Booz_xform::read_boozmn(std::string filename) {
   phi.resize(ns_in+1);
   phip.resize(ns_in+1);
   chi.resize(ns_in+1);
+  pres.resize(ns_in+1);
   nc.get("iota_b", iota_in);
   nc.get("bvco_b", Boozer_G_in);
   nc.get("buco_b", Boozer_I_in);
   nc.get("phi_b", phi);
   nc.get("phip_b", phip);
   nc.get("chi_b", chi);
+  nc.get("pres_b", pres);
   for (j = 0; j < ns_in; j++) {
       iota[j] = iota_in[j+1];
       Boozer_G_all[j] = Boozer_G_in[j+1];

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -29,11 +29,14 @@ void Booz_xform::read_wout(std::string filename, bool flux) {
 
   Vector phip0;
   Vector chi0;
+  Vector pres0;
   if (flux) {
       phip0.resize(ns);
       chi0.resize(ns);
+      pres0.resize(ns);
       nc.get("chi", chi0);
       nc.get("phipf", phip0);
+      nc.get("pres",pres0);
   }
 
   phi.resize(ns);
@@ -103,7 +106,7 @@ void Booz_xform::read_wout(std::string filename, bool flux) {
   if (flux) {
       init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
            lmnc0, lmns0, bmnc0, bmns0,
-           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0, phip0, chi0);
+           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0, phip0, chi0, pres0);
   } else {
       init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
            lmnc0, lmns0, bmnc0, bmns0,

--- a/src/_booz_xform/read_wout.cpp
+++ b/src/_booz_xform/read_wout.cpp
@@ -28,9 +28,12 @@ void Booz_xform::read_wout(std::string filename, bool flux) {
   nc.get("aspect", aspect);
 
   Vector phip0;
+  Vector chi0;
   if (flux) {
       phip0.resize(ns);
-      nc.get("chi", phip0);
+      chi0.resize(ns);
+      nc.get("chi", chi0);
+      nc.get("phipf", phip0);
   }
 
   phi.resize(ns);
@@ -100,7 +103,7 @@ void Booz_xform::read_wout(std::string filename, bool flux) {
   if (flux) {
       init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
            lmnc0, lmns0, bmnc0, bmns0,
-           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0, phip0);
+           bsubumnc0, bsubumns0, bsubvmnc0, bsubvmns0, phip0, chi0);
   } else {
       init_from_vmec(ns, iotas, rmnc0, rmns0, zmnc0, zmns0,
            lmnc0, lmns0, bmnc0, bmns0,

--- a/src/_booz_xform/write_boozmn.cpp
+++ b/src/_booz_xform/write_boozmn.cpp
@@ -86,11 +86,16 @@ void Booz_xform::write_boozmn(std::string filename) {
   beta_b.setZero();
   nc.put(radius_dim, "beta_b", pres_b, placeholder_str, "dimensionless");
   Vector phip_dummy(ns_in + 1);
+  Vector chi_dummy(ns_in + 1);
   phip_dummy.setZero();
+  chi_dummy.setZero();
   if (phip.size()==0) {
       nc.put(radius_dim, "phip_b", phip_dummy, placeholder_str, "Tesla * meter^2");
+      nc.put(radius_dim, "chi_b", chi_dummy, placeholder_str, "Tesla * meter^2");
   } else {
-      nc.put(radius_dim, "phip_b", phip, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+      phip[0] = 0;
+      nc.put(radius_dim, "phip_b", phip, "Derivative of toroidal flux (not divided by (2*pi)) with respect to s. This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+      nc.put(radius_dim, "chi_b", chi, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
   }
   nc.put(radius_dim, "phi_b", phi, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
 

--- a/src/_booz_xform/write_boozmn.cpp
+++ b/src/_booz_xform/write_boozmn.cpp
@@ -81,21 +81,21 @@ void Booz_xform::write_boozmn(std::string filename) {
   // available here. Just write vectors of zeros for
   // backwards-compatibility of the boozmn.nc files.
   Vector pres_b(ns_in + 1), beta_b(ns_in + 1);
-  pres_b.setZero();
-  nc.put(radius_dim, "pres_b", pres_b, placeholder_str, "dimensionless");
   beta_b.setZero();
   nc.put(radius_dim, "beta_b", pres_b, placeholder_str, "dimensionless");
-  Vector phip_dummy(ns_in + 1);
-  Vector chi_dummy(ns_in + 1);
+  Vector phip_dummy(ns_in + 1), chi_dummy(ns_in + 1);
   phip_dummy.setZero();
   chi_dummy.setZero();
   if (phip.size()==0) {
+      pres_b.setZero();
       nc.put(radius_dim, "phip_b", phip_dummy, placeholder_str, "Tesla * meter^2");
       nc.put(radius_dim, "chi_b", chi_dummy, placeholder_str, "Tesla * meter^2");
+      nc.put(radius_dim, "pres_b", pres_b, placeholder_str, "dimensionless");
   } else {
       phip[0] = 0;
       nc.put(radius_dim, "phip_b", phip, "Derivative of toroidal flux (not divided by (2*pi)) with respect to s. This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
       nc.put(radius_dim, "chi_b", chi, "Uniformly spaced grid going from 0 to the boundary poloidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
+      nc.put(radius_dim, "pres_b", pres, "Pressure on full vmec grid. This grid generally does not correspond to the radial grid used for other quantities in this file!", "Pascal");
   }
   nc.put(radius_dim, "phi_b", phi, "Uniformly spaced grid going from 0 to the boundary toroidal flux (not divided by (2*pi)). This grid generally does not correspond to the radial grid used for other quantities in this file!", "Tesla * meter^2");
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -22,65 +22,70 @@ class RegressionTest(unittest.TestCase):
             boozmn_new_filename = 'boozmn_new_' + configuration + '.nc'
             f = netcdf_file(os.path.join(TEST_DIR, boozmn_filename),
                                    'r', mmap=False)
-            b = Booz_xform()
-            b.read_wout(os.path.join(TEST_DIR, wout_filename))
-            # Transfer parameters from the reference file to the new
-            # calculation
-            b.mboz = f.variables['mboz_b'][()]
-            b.nboz = f.variables['nboz_b'][()]
-            b.compute_surfs = f.variables['jlist'][()] - 2
 
-            b.run()
+            for flux in [True,False]:
+                b = Booz_xform()
+                b.read_wout(os.path.join(TEST_DIR, wout_filename),flux=flux)
+                # Transfer parameters from the reference file to the new
+                # calculation
+                b.mboz = f.variables['mboz_b'][()]
+                b.nboz = f.variables['nboz_b'][()]
+                b.compute_surfs = f.variables['jlist'][()] - 2
 
-            # Compare 2D arrays
-            vars = ['bmnc_b', 'rmnc_b', 'zmns_b', 'numns_b', 'gmnc_b']
-            asym = bool(f.variables['lasym__logical__'][()])
-            if asym:
-                vars += ['bmns_b', 'rmns_b', 'zmnc_b', 'numnc_b', 'gmns_b']
+                b.run()
 
-            rtol = 1e-12
-            atol = 1e-12
-            for var in vars:
-                # gmnc_b is misspelled in the fortran version
-                var_ref = var
-                if var == 'gmnc_b':
-                    var_ref = 'gmn_b'
+                # Compare 2D arrays
+                vars = ['bmnc_b', 'rmnc_b', 'zmns_b', 'numns_b', 'gmnc_b']
+                asym = bool(f.variables['lasym__logical__'][()])
+                if asym:
+                    vars += ['bmns_b', 'rmns_b', 'zmnc_b', 'numnc_b', 'gmns_b']
 
-                # Handle the issue that we now use the variable nu,
-                # whereas the boozmn format uses the variable
-                # p = -nu.
-                sign = 1
-                if var[:2] == 'nu':
-                    sign = -1
-                    var_ref = 'p' + var[2:]
+                rtol = 1e-12
+                atol = 1e-12
+                for var in vars:
+                    # gmnc_b is misspelled in the fortran version
+                    var_ref = var
+                    if var == 'gmnc_b':
+                        var_ref = 'gmn_b'
 
-                # Reference values:
-                arr1 = f.variables[var_ref][()]
-                # Newly computed values:
-                arr2 = getattr(b, var).transpose()
+                    # Handle the issue that we now use the variable nu,
+                    # whereas the boozmn format uses the variable
+                    # p = -nu.
+                    sign = 1
+                    if var[:2] == 'nu':
+                        sign = -1
+                        var_ref = 'p' + var[2:]
 
-                print('abs diff in ' + var + ':', np.max(np.abs(arr1 - sign * arr2)))
-                np.testing.assert_allclose(arr1, sign * arr2,
-                                           rtol=rtol, atol=atol)
+                    # Reference values:
+                    arr1 = f.variables[var_ref][()]
+                    # Newly computed values:
+                    arr2 = getattr(b, var).transpose()
 
-            # Now compare some values written to the boozmn files.
-            b.write_boozmn(boozmn_new_filename)
-            f2 = netcdf_file(boozmn_new_filename)
+                    print('abs diff in ' + var + ':', np.max(np.abs(arr1 - sign * arr2)))
+                    np.testing.assert_allclose(arr1, sign * arr2,
+                                               rtol=rtol, atol=atol)
 
-            vars = f.variables.keys()
-            # These variables will not match:
-            exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'pres_b', 'beta_b', 'phip_b']
-            for var in vars:
-                if var in exclude:
-                    continue
-                # Reference values:
-                arr1 = f.variables[var][()]
-                # Newly computed values:
-                arr2 = f2.variables[var][()]
-                print('abs diff in ' + var + ':', np.max(np.abs(arr1 - arr2)))
-                np.testing.assert_allclose(arr1, arr2,
-                                           rtol=rtol, atol=atol)
-            
+                # Now compare some values written to the boozmn files.
+                b.write_boozmn(boozmn_new_filename)
+                f2 = netcdf_file(boozmn_new_filename)
+
+                vars = f.variables.keys()
+                # These variables will not match:
+                if flux:
+                    exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'pres_b', 'beta_b']
+                else:
+                    exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'pres_b', 'beta_b', 'phip_b']
+                for var in vars:
+                    if var in exclude:
+                        continue
+                    # Reference values:
+                    arr1 = f.variables[var][()]
+                    # Newly computed values:
+                    arr2 = f2.variables[var][()]
+                    print('abs diff in ' + var + ':', np.max(np.abs(arr1 - arr2)))
+                    np.testing.assert_allclose(arr1, arr2,
+                                               rtol=rtol, atol=atol)
+                
             f.close()
 
 if __name__ == '__main__':

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -72,7 +72,7 @@ class RegressionTest(unittest.TestCase):
                 vars = f.variables.keys()
                 # These variables will not match:
                 if flux:
-                    exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'pres_b', 'beta_b']
+                    exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'beta_b']
                 else:
                     exclude = ['rmax_b', 'rmin_b', 'betaxis_b', 'version', 'pres_b', 'beta_b', 'phip_b']
                 for var in vars:

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -64,6 +64,7 @@ class WriteReadTest(unittest.TestCase):
                     if flux:
                         np.testing.assert_allclose(b1.phip,b2.phip, rtol=rtol, atol=atol)
                         np.testing.assert_allclose(b1.chi,b2.chi, rtol=rtol, atol=atol)
+                        np.testing.assert_allclose(b1.pres,b2.pres, rtol=rtol, atol=atol)
                     else:
                         np.testing.assert_equal(b2.phip,0)
                         assert len(b1.phip) == 0

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -63,9 +63,12 @@ class WriteReadTest(unittest.TestCase):
                     np.testing.assert_allclose(b1.phi,b2.phi, rtol=rtol, atol=atol)
                     if flux:
                         np.testing.assert_allclose(b1.phip,b2.phip, rtol=rtol, atol=atol)
+                        np.testing.assert_allclose(b1.chi,b2.chi, rtol=rtol, atol=atol)
                     else:
                         np.testing.assert_equal(b2.phip,0)
                         assert len(b1.phip) == 0
+                        np.testing.assert_equal(b2.chi,0)
+                        assert len(b1.chi) == 0
                     os.remove(boozmn_filename)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This branch fixes a bug that was caused by #11, in which the poloidal flux was saved as the variable phip_b in the netcdf file. However, the toroidal flux derivative was saved with the same name in the STELLOPT version. The variable phip_b is now saved as the toroidal flux derivative, while the poloidal flux is saved as chi_b if read_wout is called with flux = True. The netcdf read error is handled in the case that chi_b is not written to the file. 