### PR TITLE
Initialize toroidal_flux in read_boozmn

### DIFF
--- a/src/_booz_xform/init_from_vmec.cpp
+++ b/src/_booz_xform/init_from_vmec.cpp
@@ -115,6 +115,7 @@ void Booz_xform::init_from_vmec(int ns,
      chi.resize(0);
      pres.resize(0);
      phi.resize(0);
+     toroidal_flux = 0.0;
   }
   // By default, prepare to do the Boozer transformation at all
   // half-grid surfaces:

--- a/src/_booz_xform/read_boozmn.cpp
+++ b/src/_booz_xform/read_boozmn.cpp
@@ -58,6 +58,8 @@ void Booz_xform::read_boozmn(std::string filename) {
       Boozer_I_all[j] = Boozer_I_in[j+1];
   }
 
+  toroidal_flux = phi[ns_in];
+  
   ns_b = nc.getdim("comput_surfs");
   if (verbose > 0) std::cout << "Read mboz=" << mboz << ", nboz=" << nboz <<
 		     ", mnboz=" << mnboz << ", ns_b=" << ns_b << std::endl;

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -75,7 +75,8 @@ class WriteReadTest(unittest.TestCase):
                         assert len(b1.pres) == 0
                         np.testing.assert_equal(b2.phi,0)
                         assert len(b1.phi) == 0
-                        np.testing.assert_equal(b1.toroidal_flux, b2.toroidal_flux)
+                        np.testing.assert_equal(b1.toroidal_flux,0)
+                        np.testing.assert_equal(b2.toroidal_flux,0)
                     os.remove(boozmn_filename)
 
 if __name__ == '__main__':

--- a/tests/test_write_read.py
+++ b/tests/test_write_read.py
@@ -65,6 +65,7 @@ class WriteReadTest(unittest.TestCase):
                         np.testing.assert_allclose(b1.chi,b2.chi, rtol=rtol, atol=atol)
                         np.testing.assert_allclose(b1.pres,b2.pres, rtol=rtol, atol=atol)
                         np.testing.assert_allclose(b1.phi,b2.phi, rtol=rtol, atol=atol)
+                        np.testing.assert_allclose(b1.toroidal_flux, b2.toroidal_flux, rtol=rtol, atol=atol)
                     else:
                         np.testing.assert_equal(b2.phip,0)
                         assert len(b1.phip) == 0
@@ -74,6 +75,7 @@ class WriteReadTest(unittest.TestCase):
                         assert len(b1.pres) == 0
                         np.testing.assert_equal(b2.phi,0)
                         assert len(b1.phi) == 0
+                        np.testing.assert_equal(b1.toroidal_flux, b2.toroidal_flux)
                     os.remove(boozmn_filename)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The toroidal_flux attribute is not initialized in read_boozmn(), causing wrong values when reading boozmn files:

```Python
# This works correctly
eq = Booz_xform()
eq.read_wout('wout_betaQH.nc', flux=True)
eq.toroidal_flux  # Returned: 33.637148938184666

# This fails
eq2 = Booz_xform()
eq2.read_boozmn('boozmn.nc')  
eq2.toroidal_flux  # Returned: 2.425265677e-314`
```

Added `toroidal_flux` initialization in` read_boozmn()`.